### PR TITLE
Make all public API resources immutable.

### DIFF
--- a/app/resources/api/v3/public/card_cycle_resource.rb
+++ b/app/resources/api/v3/public/card_cycle_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardCycleResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :description, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardResource < JSONAPI::Resource
+        immutable
+
         attributes :stripped_title, :title, :card_type_id, :side_id, :faction_id, :advancement_requirement, :agenda_points, :base_link, :cost, :deck_limit, :influence_cost, :influence_limit, :memory_cost, :minimum_deck_size, :strength, :stripped_text, :text, :trash_cost, :is_unique, :display_subtypes, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/card_set_resource.rb
+++ b/app/resources/api/v3/public/card_set_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardSetResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :date_release, :size, :card_cycle_id, :card_set_type_id, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/card_set_type_resource.rb
+++ b/app/resources/api/v3/public/card_set_type_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardSetTypeResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :description, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/card_subtype_resource.rb
+++ b/app/resources/api/v3/public/card_subtype_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardSubtypeResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/card_type_resource.rb
+++ b/app/resources/api/v3/public/card_type_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::CardTypeResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/faction_resource.rb
+++ b/app/resources/api/v3/public/faction_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::FactionResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :is_mini, :updated_at
         key_type :string
 

--- a/app/resources/api/v3/public/printing_resource.rb
+++ b/app/resources/api/v3/public/printing_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::PrintingResource < JSONAPI::Resource
+        immutable
+
         # Direct printing attributes
         attributes :card_id, :card_set_id, :printed_text, :stripped_printed_text, :printed_is_unique, :flavor, :illustrator, :position, :quantity, :date_release, :updated_at
 

--- a/app/resources/api/v3/public/side_resource.rb
+++ b/app/resources/api/v3/public/side_resource.rb
@@ -2,6 +2,8 @@ module API
   module V3
     module Public
       class Api::V3::Public::SideResource < JSONAPI::Resource
+        immutable
+
         attributes :name, :updated_at
         key_type :string
 


### PR DESCRIPTION
This only produces GET routes for these resources, which is what we want for the public API.