### PR TITLE
add rack-cors and update CORS headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
-
 gem "rack"
+# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
+gem "rack-cors"
 
 # Used for our import of the card data.
 gem "activerecord-import"
@@ -58,4 +57,3 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,10 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.4)
@@ -135,6 +139,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3.1)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -195,6 +201,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  universal-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -209,6 +216,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.6)
   rack
+  rack-cors
   rails (~> 7.0)
   rspec-rails
   tzinfo-data
@@ -217,4 +225,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.3.3
+   2.3.15

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :options, :head]
+  end
+end


### PR DESCRIPTION
This PR:
* adds back in the `rack-cors` gem
* allows CORS `get`/`option`/`head` requests from any origin