### PR TITLE
Snapshots now directly expose their card sets/cycles instead of linking to a card pool

### DIFF
--- a/app/resources/api/v3/public/snapshot_resource.rb
+++ b/app/resources/api/v3/public/snapshot_resource.rb
@@ -3,15 +3,23 @@ module API
     module Public
       class Api::V3::Public::SnapshotResource < JSONAPI::Resource
         immutable
-        
-        attributes :active, :date_start, :updated_at
+
+        attributes :active, :card_cycle_ids, :card_set_ids, :date_start, :updated_at
         key_type :string
 
         paginator :none
 
         belongs_to :format
-        has_one :card_pool
+        # has_one :card_pool
         has_one :restriction
+
+        def card_cycle_ids
+          @model.card_pool.card_pool_card_cycles.pluck(:card_cycle_id)
+        end
+
+        def card_set_ids
+          @model.card_pool.card_pool_card_sets.pluck(:card_set_id)
+        end
       end
     end
   end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26557961/177058079-5abe091e-423c-41f6-9542-05285e3cf5e6.png)
