### PR TITLE
Expose some additional fields for ease of use

### DIFF
--- a/app/resources/api/v3/public/card_pool_resource.rb
+++ b/app/resources/api/v3/public/card_pool_resource.rb
@@ -3,8 +3,8 @@ module API
     module Public
       class Api::V3::Public::CardPoolResource < JSONAPI::Resource
         immutable
-        
-        attributes :name, :updated_at
+
+        attributes :name, :card_cycle_ids, :card_set_ids, :card_ids, :updated_at
         key_type :string
 
         paginator :none

--- a/app/resources/api/v3/public/format_resource.rb
+++ b/app/resources/api/v3/public/format_resource.rb
@@ -3,8 +3,8 @@ module API
     module Public
       class Api::V3::Public::FormatResource < JSONAPI::Resource
         immutable
-        
-        attributes :name, :active_snapshot_id, :updated_at
+
+        attributes :name, :active_snapshot_id, :snapshot_ids, :updated_at
         key_type :string
 
         paginator :none

--- a/app/resources/api/v3/public/snapshot_resource.rb
+++ b/app/resources/api/v3/public/snapshot_resource.rb
@@ -4,7 +4,7 @@ module API
       class Api::V3::Public::SnapshotResource < JSONAPI::Resource
         immutable
 
-        attributes :format_id, :active, :card_cycle_ids, :card_set_ids, :date_start, :updated_at
+        attributes :format_id, :active, :card_cycle_ids, :card_set_ids, :card_pool_id, :restriction_id, :date_start, :updated_at
         key_type :string
 
         paginator :none


### PR DESCRIPTION
Snapshots:
- exposed `card_pool_id`
- exposed `restriction_id`
Formats:
- exposed `snapshot_ids`
Card pools:
- exposed `card_cycle_ids`
- exposed `card_set_ids`
- exposed `card_ids`

Without this change you have to make an additional api call to find these values; I don't know if that's how we want it but it's a non-insignificant hassle for updating the Discord bot.