### PR TITLE
Add legacy_code support for cycles and sets.

### DIFF
--- a/app/resources/api/v3/public/card_cycle_resource.rb
+++ b/app/resources/api/v3/public/card_cycle_resource.rb
@@ -4,7 +4,7 @@ module API
       class Api::V3::Public::CardCycleResource < JSONAPI::Resource
         immutable
 
-        attributes :name, :date_release, :updated_at
+        attributes :name, :date_release, :legacy_code, :updated_at
         key_type :string
 
         has_many :card_sets

--- a/app/resources/api/v3/public/card_set_resource.rb
+++ b/app/resources/api/v3/public/card_set_resource.rb
@@ -4,7 +4,7 @@ module API
       class Api::V3::Public::CardSetResource < JSONAPI::Resource
         immutable
 
-        attributes :name, :date_release, :size, :card_cycle_id, :card_set_type_id, :updated_at
+        attributes :name, :date_release, :size, :card_cycle_id, :card_set_type_id, :legacy_code, :updated_at
         key_type :string
 
         paginator :none

--- a/db/migrate/20220831025326_add_legacy_code_to_card_cycles.rb
+++ b/db/migrate/20220831025326_add_legacy_code_to_card_cycles.rb
@@ -1,0 +1,5 @@
+class AddLegacyCodeToCardCycles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :card_cycles, :legacy_code, :string
+  end
+end

--- a/db/migrate/20220831025337_add_legacy_code_to_card_sets.rb
+++ b/db/migrate/20220831025337_add_legacy_code_to_card_sets.rb
@@ -1,0 +1,5 @@
+class AddLegacyCodeToCardSets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :card_sets, :legacy_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_26_032417) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_31_025337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_032417) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "date_release"
+    t.string "legacy_code"
   end
 
   create_table "card_pools", id: :string, force: :cascade do |t|
@@ -63,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_032417) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "legacy_code"
   end
 
   create_table "card_subtypes", id: :string, force: :cascade do |t|

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -162,6 +162,7 @@ namespace :cards do
       {
         id: c['id'],
         name: c['name'],
+        legacy_code: c['legacy_code']
       }
     end
     CardCycle.import cycles, on_duplicate_key_update: { conflict_target: [ :id ], columns: :all }
@@ -198,6 +199,7 @@ namespace :cards do
           "card_cycle_id": s["card_cycle_id"],
           "card_set_type_id": s["card_set_type_id"],
           "position": s["position"],
+          "legacy_code": s["legacy_code"]
       }
     end
     CardSet.import printings, on_duplicate_key_update: { conflict_target: [ :id ], columns: :all }


### PR DESCRIPTION
Add support for legacy_codes to enable interop with NRDB classic.

Since the new app has different ids (the mechanical transformation of the names or card titles), we need to be explicit about the mapping.