### PR TITLE
Updated importer to add card set types' descriptions

### DIFF
--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -174,6 +174,7 @@ namespace :cards do
       {
         id: t['id'],
         name: t['name'],
+        description: t['description'],
       }
     end
     CardSetType.import set_types, on_duplicate_key_update: { conflict_target: [ :id ], columns: :all }


### PR DESCRIPTION
It turns out the database was already set up for this and the field was already exposed in the resource.