### PR TITLE
Some qol changes in restrictions

### DIFF
--- a/app/resources/api/v3/public/format_resource.rb
+++ b/app/resources/api/v3/public/format_resource.rb
@@ -4,7 +4,9 @@ module API
       class Api::V3::Public::FormatResource < JSONAPI::Resource
         immutable
 
-        attributes :name, :active_snapshot_id, :snapshot_ids, :updated_at
+        attributes :name, :active_snapshot_id, :snapshot_ids
+        attribute :active_restriction_id
+        attribute :updated_at
         key_type :string
 
         paginator :none
@@ -12,6 +14,10 @@ module API
         has_many :card_pools
         has_many :restrictions
         has_many :snapshots
+
+        def active_restriction_id
+          @model.snapshots.find_by(active: true).restriction_id
+        end
       end
     end
   end

--- a/app/resources/api/v3/public/restriction_resource.rb
+++ b/app/resources/api/v3/public/restriction_resource.rb
@@ -3,14 +3,24 @@ module API
     module Public
       class Api::V3::Public::RestrictionResource < JSONAPI::Resource
         immutable
-        
+
         attributes :name, :date_start, :point_limit
-        attributes :banned, :restricted, :universal_faction_cost, :global_penalty, :points
+        attribute :verdicts
         attribute :banned_subtypes
+        attribute :size
         attribute :updated_at
         key_type :string
 
         paginator :none
+
+        def verdicts
+          { 'banned': banned,
+            'restricted': restricted,
+            'universal_faction_cost': universal_faction_cost,
+            'global_penalty': global_penalty,
+            'points': points
+          }
+        end
 
         def banned
           @model.banned_cards.pluck(:card_id)
@@ -34,6 +44,14 @@ module API
 
         def banned_subtypes
           @model.banned_subtypes.pluck(:card_subtype_id)
+        end
+
+        def size
+          banned.length() +
+          restricted.length() +
+          universal_faction_cost.map { |_,a| a.length() }.sum() +
+          global_penalty.map { |_,a| a.length() }.sum() +
+          points.map { |_,a| a.length() }.sum()
         end
       end
     end


### PR DESCRIPTION
- packaged each restriction's banlist, restricted list, etc. in a single field `verdicts`
- added an attribute to restrictions counting the number of cards affected by them
- exposed the id of the active restriction of each format