### PR TITLE
Exposed the latest printing id of each card

### DIFF
--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -8,9 +8,8 @@ module API
         attributes :advancement_requirement, :agenda_points, :base_link, :cost
         attributes :deck_limit, :influence_cost, :influence_limit, :memory_cost
         attributes :minimum_deck_size, :strength, :stripped_text, :text, :trash_cost
-        attributes :is_unique, :display_subtypes
+        attributes :is_unique, :display_subtypes, :updated_at
         attribute :latest_printing_id
-        attribute :updated_at
 
         key_type :string
 

--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -8,7 +8,9 @@ module API
         attributes :advancement_requirement, :agenda_points, :base_link, :cost
         attributes :deck_limit, :influence_cost, :influence_limit, :memory_cost
         attributes :minimum_deck_size, :strength, :stripped_text, :text, :trash_cost
-        attributes :is_unique, :display_subtypes, :updated_at
+        attributes :is_unique, :display_subtypes
+        attribute :latest_printing_id
+        attribute :updated_at
 
         key_type :string
 
@@ -17,6 +19,10 @@ module API
         has_one :card_type
         has_many :card_subtypes
         has_many :printings
+
+        def latest_printing_id
+          @model.printings[-1]['id']
+        end
 
         filters :title, :card_type_id, :side_id, :faction_id, :advancement_requirement
         filters :agenda_points, :base_link, :cost, :deck_limit, :influence_cost


### PR DESCRIPTION
This lets you get a link for a card (not printing) without running a separate api call on printings. I don't know if this would be better as a relationship.