### PR TITLE
Two small things

### DIFF
--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -20,7 +20,7 @@ module API
         has_many :printings
 
         def latest_printing_id
-          @model.printings[-1]['id']
+          @model.printings.max_by { |p| p.date_release } ['id']
         end
 
         filters :title, :card_type_id, :side_id, :faction_id, :advancement_requirement

--- a/app/resources/api/v3/public/format_resource.rb
+++ b/app/resources/api/v3/public/format_resource.rb
@@ -4,9 +4,8 @@ module API
       class Api::V3::Public::FormatResource < JSONAPI::Resource
         immutable
 
-        attributes :name, :active_snapshot_id, :snapshot_ids
-        attribute :active_restriction_id
-        attribute :updated_at
+        attributes :name, :active_snapshot_id, :snapshot_ids, :updated_at
+        attributes :active_card_pool_id, :active_restriction_id
         key_type :string
 
         paginator :none
@@ -14,6 +13,10 @@ module API
         has_many :card_pools
         has_many :restrictions
         has_many :snapshots
+
+        def active_card_pool_id
+          @model.snapshots.find_by(active: true).card_pool_id
+        end
 
         def active_restriction_id
           @model.snapshots.find_by(active: true).restriction_id


### PR DESCRIPTION
- Fixed cards assuming their printings were in release date order
- Exposed active card pool ID in formats