### PR TITLE
Add first batch of advanced card attributes to API & search.

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -15,4 +15,20 @@ class Card < ApplicationRecord
   has_many :unified_restrictions
 
   validates :name, uniqueness: true
+
+  def advancement_requirement
+    self[:advancement_requirement] == -1 ? 'X' : self[:advancement_requirement]
+  end
+   def link_provided
+    self[:link_provided] == -1 ? 'X' : self[:link_provided]
+  end
+  def mu_provided
+    self[:mu_provided] == -1 ? 'X' : self[:mu_provided]
+  end
+  def num_printed_subroutines
+    self[:num_printed_subroutines] == -1 ? 'X' : self[:num_printed_subroutines]
+  end
+  def recurring_credits_provided
+    self[:recurring_credits_provided] == -1 ? 'X' : self[:recurring_credits_provided]
+  end
 end

--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -9,7 +9,7 @@ module API
         attributes :deck_limit, :influence_cost, :influence_limit, :memory_cost
         attributes :minimum_deck_size, :strength, :stripped_text, :text, :trash_cost
         attributes :is_unique, :display_subtypes, :updated_at
-        attribute :latest_printing_id
+        attributes :card_abilities, :latest_printing_id
 
         key_type :string
 
@@ -21,6 +21,22 @@ module API
 
         def latest_printing_id
           @model.printings.max_by { |p| p.date_release } ['id']
+        end
+
+        def card_abilities
+          {
+            additional_cost: @model.additional_cost,
+            advanceable: @model.advanceable,
+            gains_subroutines: @model.gains_subroutines,
+            interrupt: @model.interrupt,
+            link_provided: @model.link_provided,
+            mu_provided: @model.mu_provided,
+            num_printed_subroutines: @model.num_printed_subroutines,
+            on_encounter_effect: @model.on_encounter_effect,
+            performs_trace: @model.performs_trace,
+            recurring_credits_provided: @model.recurring_credits_provided,
+            trash_ability: @model.trash_ability,
+          }
         end
 
         filters :title, :card_type_id, :side_id, :faction_id, :advancement_requirement

--- a/app/resources/api/v3/public/printing_resource.rb
+++ b/app/resources/api/v3/public/printing_resource.rb
@@ -10,9 +10,9 @@ module API
         attributes :quantity, :date_release, :updated_at
 
         # Parent Card attributes, included inline to make printings a bit more useful.
-        attributes :advancement_requirement, :agenda_points, :base_link, :card_type_id
-        attributes :cost, :deck_limit, :display_subtypes, :faction_id, :influence_cost
-        attributes :influence_limit, :is_unique, :memory_cost, :minimum_deck_size
+        attributes :advancement_requirement, :agenda_points, :base_link, :card_abilities
+        attributes :card_type_id, :cost, :deck_limit, :display_subtypes, :faction_id
+        attributes :influence_cost, :influence_limit, :is_unique, :memory_cost, :minimum_deck_size
         attributes :side_id, :strength, :stripped_text, :stripped_title, :text
         attributes :title, :trash_cost
 
@@ -121,6 +121,21 @@ module API
         end
         def base_link
           @model.card.base_link
+        end
+        def card_abilities
+          {
+            additional_cost: @model.card.additional_cost,
+            advanceable: @model.card.advanceable,
+            gains_subroutines: @model.card.gains_subroutines,
+            interrupt: @model.card.interrupt,
+            link_provided: @model.card.link_provided,
+            mu_provided: @model.card.mu_provided,
+            num_printed_subroutines: @model.card.num_printed_subroutines,
+            on_encounter_effect: @model.card.on_encounter_effect,
+            performs_trace: @model.card.performs_trace,
+            recurring_credits_provided: @model.card.recurring_credits_provided,
+            trash_ability: @model.card.trash_ability,
+          }
         end
         def card_type_id
           @model.card.card_type_id

--- a/lib/card_search_parser.rb
+++ b/lib/card_search_parser.rb
@@ -18,6 +18,8 @@ class CardSearchParser < Parslet::Parser
   # Note that while this list should generally be kept sorted, an entry that is a prefix of
   # a later entry will clobber the later entries and throw an error parsing text with the later entries.
   rule(:keyword) {
+    str('additional_cost') |
+    str('advanceable') |
     str('advancement_cost') |
     str('agenda_points') |
     str('base_link') |
@@ -28,19 +30,28 @@ class CardSearchParser < Parslet::Parser
     str('eternal_points') |
     str('faction') |
     str('format') |
+    str('gains_subroutines') |
     str('global_penalty') |
     str('illustrator') |
     str('in_restriction') |
     str('influence_cost') |
+    str('interrupt') |
     str('is_banned') |
     str('is_restricted') |
     str('is_unique') |
+    str('link_provided') |
     str('memory_usage') |
+    str('mu_provided') |
+    str('num_printed_subroutines') |
+    str('on_encounter_effect') |
+    str('performs_trace') |
+    str('recurring_credits_provided') |
     str('restriction_id') |
     str('side') |
     str('strength') |
     str('text') |
     str('title') |
+    str('trash_ability') |
     str('trash_cost') |
     str('universal_faction_cost') |
     # Single letter 'short codes'

--- a/lib/card_search_query_builder.rb
+++ b/lib/card_search_query_builder.rb
@@ -1,12 +1,19 @@
 class CardSearchQueryBuilder
     @@parser = CardSearchParser.new
     @@boolean_keywords = [
+        'additional_cost',
+        'advanceable',
         'b',
         'banlist',
+        'gains_subroutines',
         'in_restriction',
+        'interrupt',
         'is_banned',
         'is_restricted',
         'is_unique',
+        'on_encounter_effect',
+        'performs_trace',
+        'trash_ability',
         'u',
     ]
     @@numeric_keywords = [
@@ -20,11 +27,15 @@ class CardSearchQueryBuilder
         'h',
         'influence_cost',
         'l',
+        'link_provided',
         'm',
         'memory_usage',
+        'mu_provided',
         'n',
+        'num_printed_subroutines',
         'o',
         'p',
+        'recurring_credits_provided',
         'strength',
         'trash_cost',
         'universal_faction_cost',
@@ -62,6 +73,8 @@ class CardSearchQueryBuilder
     @@term_to_field_map = {
         # format should implicitly use the currently active card pool and restriction lists unless another is specified.
         '_' => 'cards.stripped_title',
+        'additional_cost' => 'cards.additional_cost',
+        'advanceable' => 'cards.advanceable',
         'advancement_cost' => 'cards.advancement_requirement',
         'agenda_points' => 'cards.agenda_points',
         'base_link' => 'cards.base_link',
@@ -75,19 +88,27 @@ class CardSearchQueryBuilder
         'faction' => 'cards.faction_id',
         'format' => 'unified_restrictions.format_id',
         'g' => 'cards.advancement_requirement',
+        'gains_subroutines' => 'cards.gains_subroutines',
         'global_penalty' => 'unified_restrictions.global_penalty',
         'h' => 'cards.trash_cost',
         'in_restriction' => 'unified_restrictions.in_restriction',
         'influence_cost' => 'cards.influence_cost',
+        'interrupt' => 'cards.interrupt',
         'is_banned' => 'unified_restrictions.is_banned',
         'is_restricted' => 'unified_restrictions.is_restricted',
         'is_unique' => 'cards.is_unique',
         'l' => 'cards.base_link',
+        'link_provided' => 'cards.link_provided',
         'm' => 'cards.memory_cost',
         'memory_usage' => 'cards.memory_cost',
+        'mu_provided' => 'cards.mu_provided',
         'n' => 'cards.influence_cost',
+        'num_printed_subroutines' => 'cards.num_printed_subroutines',
         'o' => 'cards.cost',
+        'on_encounter_effect' => 'cards.on_encounter_effect',
         'p' => 'cards.strength',
+        'performs_trace' => 'cards.performs_trace',
+        'recurring_credits_provided' => 'cards.recurring_credits_provided',
         'restriction_id' => 'unified_restrictions.restriction_id',
         's' => 'card_subtypes.name',
         'side' => 'cards.card_side_id',
@@ -95,6 +116,7 @@ class CardSearchQueryBuilder
         't' => 'cards.card_type_id',
         'text' => 'cards.stripped_text',
         'title' => 'cards.stripped_title',
+        'trash_ability' => 'cards.trash_ability',
         'trash_cost' => 'cards.trash_cost',
         'u' => 'cards.is_unique',
         'universal_faction_cost' => 'unified_restrictions.universal_faction_cost',
@@ -155,19 +177,19 @@ class CardSearchQueryBuilder
                     constraints << '%s %s ?' % [@@term_to_field_map[keyword], operator]
                     where << value
                 elsif @@numeric_keywords.include?(keyword)
-                    if !value.match?(/\A\d+\Z/)
+                    if !value.match?(/\A(\d+|x)\Z/i)
                         @parse_error = 'Invalid value "%s" for integer field "%s"' % [value, keyword]
                         return
                     end 
                     operator = ''
-                   if @@numeric_operators.include?(match_type)
+                    if @@numeric_operators.include?(match_type)
                         operator = @@numeric_operators[match_type]
                     else
                         @parse_error = 'Invalid numeric operator "%s"' % match_type
                         return
                     end
                     constraints << '%s %s ?' % [@@term_to_field_map[keyword], operator]
-                    where << value 
+                    where << (value.downcase == 'x' ? -1 : value) 
                 else
                     # String fields only support : and !, resolving to to {,NOT} LIKE %value%.
                     # TODO(plural): consider ~ for regex matches. 
@@ -178,7 +200,7 @@ class CardSearchQueryBuilder
                         @parse_error = 'Invalid string operator "%s"' % match_type
                         return
                     end
-                   constraints << 'lower(%s) %s ?' % [@@term_to_field_map[keyword], operator]
+                    constraints << 'lower(%s) %s ?' % [@@term_to_field_map[keyword], operator]
                     where << '%%%s%%' % value
                 end
                 if @@term_to_left_join_map.include?(keyword)

--- a/lib/printing_search_parser.rb
+++ b/lib/printing_search_parser.rb
@@ -18,6 +18,8 @@ class PrintingSearchParser < Parslet::Parser
   # Note that while this list should generally be kept sorted, an entry that is a prefix of
   # a later entry will clobber the later entries and throw an error parsing text with the later entries.
   rule(:keyword) {
+    str('additional_cost') |
+    str('advanceable') |
     str('advancement_cost') |
     str('agenda_points') |
     str('base_link') |
@@ -31,21 +33,30 @@ class PrintingSearchParser < Parslet::Parser
     str('faction') |
     str('flavor') |
     str('format') |
+    str('gains_subroutines') |
     str('global_penalty') |
     str('illustrator') |
     str('in_restriction') |
     str('influence_cost') |
+    str('interrupt') |
     str('is_banned') |
     str('is_restricted') |
     str('is_unique') |
+    str('link_provided') |
     str('memory_usage') |
+    str('mu_provided') |
+    str('num_printed_subroutines') |
+    str('on_encounter_effect') |
+    str('performs_trace') |
     str('quantity') |
+    str('recurring_credits_provided') |
     str('release_date') |
     str('restriction_id') |
     str('side') |
     str('strength') |
     str('text') |
     str('title') |
+    str('trash_ability') |
     str('trash_cost') |
     str('universal_faction_cost') |
     # Single letter 'short codes'

--- a/lib/printing_search_query_builder.rb
+++ b/lib/printing_search_query_builder.rb
@@ -1,12 +1,19 @@
 class PrintingSearchQueryBuilder
     @@parser = PrintingSearchParser.new
     @@boolean_keywords = [
+        'additional_cost',
+        'advanceable',
         'b',
         'banlist',
+        'gains_subroutines',
         'in_restriction',
+        'interrupt',
         'is_banned',
         'is_restricted',
         'is_unique',
+        'on_encounter_effect',
+        'performs_trace',
+        'trash_ability',
         'u',
     ]
     @@date_keywords = [
@@ -24,12 +31,16 @@ class PrintingSearchQueryBuilder
         'h',
         'influence_cost',
         'l',
+        'link_provided',
         'm',
         'memory_usage',
+        'mu_provided',
         'n',
+        'num_printed_subroutines',
         'o',
         'p',
         'quantity',
+        'recurring_credits_provided',
         'strength',
         'trash_cost',
         'universal_faction_cost',
@@ -81,6 +92,8 @@ class PrintingSearchQueryBuilder
     @@term_to_field_map = {
         '_' => 'cards.stripped_title',
         'a' => 'printings.flavor',
+        'additional_cost' => 'cards.additional_cost',
+        'advanceable' => 'cards.advanceable',
         'advancement_cost' => 'cards.advancement_requirement',
         'agenda_points' => 'cards.agenda_points',
         'base_link' => 'cards.base_link',
@@ -99,23 +112,31 @@ class PrintingSearchQueryBuilder
         'flavor' => 'printings.flavor',
         'format' => 'unified_restrictions.format_id',
         'g' => 'cards.advancement_requirement',
+        'gains_subroutines' => 'cards.gains_subroutines',
         'global_penalty' => 'unified_restrictions.global_penalty',
         'h' => 'cards.trash_cost',
         'i' => 'illustrators.name',
         'illustrator' => 'illustrators.name',
         'in_restriction' => 'unified_restrictions.in_restriction',
         'influence_cost' => 'cards.influence_cost',
+        'interrupt' => 'cards.interrupt',
         'is_banned' => 'unified_restrictions.is_banned',
         'is_restricted' => 'unified_restrictions.is_restricted',
         'is_unique' => 'cards.is_unique',
         'l' => 'cards.base_link',
+        'link_provided' => 'cards.link_provided',
         'm' => 'cards.memory_cost',
         'memory_usage' => 'cards.memory_cost',
+        'mu_provided' => 'cards.mu_provided',
         'n' => 'cards.influence_cost',
+        'num_printed_subroutines' => 'cards.num_printed_subroutines',
         'o' => 'cards.cost',
+        'on_encounter_effect' => 'cards.on_encounter_effect',
         'p' => 'cards.strength',
+        'performs_trace' => 'cards.performs_trace',
         'quantity' => 'printings.quantity',
         'r' => 'printings.date_release',
+        'recurring_credits_provided' => 'cards.recurring_credits_provided',
         'release_date' => 'printings.date_release',
         'restriction_id' => 'unified_restrictions.restriction_id',
         's' => 'card_subtypes.name',
@@ -124,6 +145,7 @@ class PrintingSearchQueryBuilder
         't' => 'cards.card_type_id',
         'text' => 'cards.stripped_text',
         'title' => 'cards.stripped_title',
+        'trash_ability' => 'cards.trash_ability',
         'trash_cost' => 'cards.trash_cost',
         'u' => 'cards.is_unique',
         'universal_faction_cost' => 'unified_restrictions.universal_faction_cost',
@@ -135,6 +157,8 @@ class PrintingSearchQueryBuilder
     # TODO(plural): Unify more of this with card_search_query_builder.
     @@term_to_left_join_map = {
         '_' => :card,
+        'additional_cost' => :card,
+        'advanceable' => :card,
         'advancement_cost' => :card,
         'agenda_points' => :card,
         'base_link' => :card,
@@ -150,21 +174,29 @@ class PrintingSearchQueryBuilder
         'faction' => :card,
         'format' => :unified_restrictions,
         'g' => :card,
+        'gains_subroutines' => :card,
         'global_penalty' => :unified_restrictions,
         'h' => :card,
         'i' => :illustrators,
         'illustrator' => :illustrators,
         'in_restriction' => :unified_restrictions,
         'influence_cost' => :card,
+        'interrupt' => :card,
         'is_banned' => :unified_restrictions,
         'is_restricted' => :unified_restrictions,
         'is_unique' => :card,
         'l' => :card,
+        'link_provided' => :card,
         'm' => :card,
         'memory_usage' => :card,
+        'mu_provided' => :card,
         'n' => :card,
+        'num_printed_subroutines' => :card,
         'o' => :card,
+        'on_encounter_effect' => :card,
         'p' => :card,
+        'performs_trace' => :card,
+        'recurring_credits_provided' => :card,
         'restriction_id' => :unified_restrictions,
         's' => :card_subtypes,
         'side' => :card,
@@ -172,6 +204,7 @@ class PrintingSearchQueryBuilder
         't' => :card,
         'text' => :card,
         'title' => :card,
+        'trash_ability' => :card,
         'trash_cost' => :card,
         'u' => :card,
         'universal_faction_cost' => :unified_restrictions,
@@ -233,7 +266,7 @@ class PrintingSearchQueryBuilder
                     constraints << '%s %s ?' % [@@term_to_field_map[keyword], operator]
                     where << value 
                 elsif @@numeric_keywords.include?(keyword)
-                    if !value.match?(/\A\d+\Z/)
+                    if !value.match?(/\A(\d+|x)\Z/i)
                         @parse_error = 'Invalid value "%s" for integer field "%s"' % [value, keyword]
                         return
                     end 
@@ -245,7 +278,7 @@ class PrintingSearchQueryBuilder
                         return
                     end
                     constraints << '%s %s ?' % [@@term_to_field_map[keyword], operator]
-                    where << value 
+                    where << (value.downcase == 'x' ? -1 : value)
                 else
                     # String fields only support : and !, resolving to to {,NOT} LIKE %value%.
                     # TODO(plural): consider ~ for regex matches. 

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -90,7 +90,6 @@ namespace :cards do
         card_type_id: card["card_type_id"],
         side_id: card["side_id"],
         faction_id: card["faction_id"],
-        advancement_requirement: card["advancement_requirement"],
         agenda_points: card["agenda_points"],
         base_link: card["base_link"],
         cost: card["cost"],
@@ -109,12 +108,15 @@ namespace :cards do
         display_subtypes: flatten_subtypes(subtypes, card["subtypes"]),
       )
 
+      if new_card.card_type_id == 'agenda'
+        new_card.advancement_requirement = (card["advancement_requirement"].nil? ? -1 : card["advancement_requirement"])
+      end
+
       # Look for specific abilities and attributes:
       if new_card.text 
         m = new_card.text.match(/\+([X\d]+)\[link\]/)
         if m && m.captures.length == 1
           link_provided = m.captures[0]
-          puts "provides_link: [%s] [%s] %s\n-----------------\n" % [link_provided, new_card.title, new_card.text]
           # Null is equivalent to "does not provide link" and we will use -1 to map to X.
           new_card.link_provided = link_provided == 'X' ? -1 : link_provided
         end
@@ -124,9 +126,9 @@ namespace :cards do
         m = new_card.text.match(/\+([X\d]+)\[mu\]/)
         if m && m.captures.length == 1
           mu_provided = m.captures[0]
-          puts "provides_mu: [%s] [%s] %s\n-----------------\n" % [mu_provided, new_card.title, new_card.text]
           # Null is equivalent to "does not provide mu" and we will use -1 to map to X.
-          new_card.mu_provided = mu_provided == 'X' ? -1 : mu_provided
+          puts 'mu_provided for %s is %s' % [new_card.id, mu_provided]
+          new_card.mu_provided = (mu_provided == 'X' ? -1 : mu_provided)
         end
       end
 
@@ -134,20 +136,17 @@ namespace :cards do
         m = new_card.text.match('([X\d]+)\[recurring-credit\]')
         if m && m.captures.length == 1
           num_recurring_credits = m.captures[0]
-          puts "provides_recurring_credits: [%s] [%s] %s\n-----------------\n" % [num_recurring_credits, new_card.title, new_card.text]
           # Null is equivalent to "does not provide recurring credits" and we will use -1 to map to X.
           new_card.recurring_credits_provided = num_recurring_credits == 'X' ? -1 : num_recurring_credits
         end
       end
 
       if new_card.text && new_card.text.include?('[interrupt] →')
-        puts "has_interrupt: [%s] %s\n-----------------\n" % [new_card.title, new_card.text]
         new_card.interrupt = true
       end
 
       # Geist and Tech trader are more trash *triggers* than abilities.
       if new_card.text && new_card.text.include?('[trash]')
-        puts "has_trash_ability: [%s] %s\n-----------------\n" % [new_card.title, new_card.text]
         new_card.trash_ability = true
       end
 
@@ -162,36 +161,30 @@ namespace :cards do
           t = t.gsub(/gains "\[subroutine\].*?"/, '')
         end
         num_printed_subroutines = t.scan(/\[subroutine\]/).length
-        puts 'subs: [%s] gains_subroutines=%s, num_printed_subroutines=%d : %s' % [new_card.title, gains_subroutines, num_printed_subroutines, new_card.text]
         new_card.gains_subroutines = gains_subroutines
         new_card.num_printed_subroutines = num_printed_subroutines
       end
 
       if new_card.text && new_card.text.include?(' can be advanced')
         if new_card.text.match('%s can be advanced' % new_card.title)
-          puts 'advanceable: [%s]: %s' % [new_card.title, new_card.text]
           new_card.advanceable = true
         end
       end
 
       # leaving this vague to catch things that have and impose additional costs.
       if new_card.text && new_card.text.include?('As an additional cost to')
-        puts 'additional_cost: [%s]: %s' % [new_card.title, new_card.text]
         new_card.additional_cost = true
       end
 
       if new_card.text && (new_card.text.include?('When the Runner encounters this ice') || new_card.text.include?('When the Runner encounters %s' % new_card.title))
-        puts 'on_encounter_effect: [%s]: %s' % [new_card.title, new_card.text]
         new_card.on_encounter_effect = true
       end
 
       if new_card.text && (new_card.text.include?('When you rez') || new_card.text.include?('%s when it is rezzed' % new_card.title))
-        puts 'rez_effect: [%s]: %s' % [new_card.title, new_card.text]
         new_card.rez_effect
       end
 
       if new_card.text && (new_card.text.match?(/trace(\[\d+| X| \d+)/i) || new_card.text.match?('<trace>'))
-        puts 'performs_trace: [%s]: %s' % [new_card.title, new_card.text]
         new_card.performs_trace = true
       end
 

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -127,7 +127,6 @@ namespace :cards do
         if m && m.captures.length == 1
           mu_provided = m.captures[0]
           # Null is equivalent to "does not provide mu" and we will use -1 to map to X.
-          puts 'mu_provided for %s is %s' % [new_card.id, mu_provided]
           new_card.mu_provided = (mu_provided == 'X' ? -1 : mu_provided)
         end
       end


### PR DESCRIPTION
This wires up attributes from #99 to the resources in the API and the search filters.

Cards and printings now have this:
```
"card_abilities": {
  "additional_cost": false,
  "advanceable": false,
  "gains_subroutines": false,
  "interrupt": false,
  "link_provided": null,
  "mu_provided": null,
  "num_printed_subroutines": null,
  "on_encounter_effect": false,
  "performs_trace": false,
  "recurring_credits_provided": "X",
  "trash_ability": false
},
```

and each attribute is wired up in the filter[search] syntax.

This also adds handling of X for numeric types and updates X agenda points to be -1 instead of NULL to make our X types more consistent (straight costs still need it).