### PR TITLE
Make the search operator query distinct.

### DIFF
--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -48,6 +48,7 @@ module API
           if query_builder.parse_error.nil?
               records.left_joins(query_builder.left_joins)
                   .where(query_builder.where, *query_builder.where_values)
+                  .distinct
           else
             raise JSONAPI::Exceptions::BadRequest.new(
                 'Invalid search query: [%s] / %s' % [value[0], query_builder.parse_error])

--- a/app/resources/api/v3/public/printing_resource.rb
+++ b/app/resources/api/v3/public/printing_resource.rb
@@ -88,6 +88,7 @@ module API
           if query_builder.parse_error.nil?
               records.left_joins(query_builder.left_joins)
                   .where(query_builder.where, *query_builder.where_values)
+                  .distinct
           else
             raise JSONAPI::Exceptions::BadRequest.new(
                 'Invalid search query: [%s] / %s' % [value[0], query_builder.parse_error])


### PR DESCRIPTION
This fixes a weird issue with the search operator.

Before this, a query like: http://localhost:3000/api/v3/public/cards?filter%5Bsearch%5D=in_restriction%3Atrue&page[limit]=250&page[offset]=0

would return paging links along the default 100 items lines, but the data would only have a handful of records.  It was pulling back the same card_id from the unified_restrictions join multiple times (1 per restriction a card is on), applying paging, then deduping before the results were sent.

This makes things behave as expected.

Note: The rails query thing does "find all the ids" then "select * from the model's table where id = ?" for each one.  :/. The query above takes almost 400ms on my local machine, but I think with a materialized view we can get that down < 100ms pretty easily.