### PR TITLE
Forced the snapshot and restriction IDs of formats to be ordered

### DIFF
--- a/app/resources/api/v3/public/format_resource.rb
+++ b/app/resources/api/v3/public/format_resource.rb
@@ -21,6 +21,14 @@ module API
         def active_restriction_id
           @model.snapshots.find_by(active: true).restriction_id
         end
+
+        def snapshot_ids
+          @model.snapshots.sort_by { |s| s.date_start }.map { |s| s.id }
+        end
+
+        def restriction_ids
+          @model.restrictions.sort_by { |r| r.date_start }.map { |r| r.id }
+        end
       end
     end
   end


### PR DESCRIPTION
The [current version](https://api-preview.netrunnerdb.com/api/v3/public/formats/standard/) has the most recent two IDs placed out of order. Debugging suggests the server is cursed.

Let me know if this isn't the best way to do this.