### PR TITLE
Add partials that fix explanation rendering.

### DIFF
--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -1,0 +1,49 @@
+<h2><%= example['description'] %></h2>
+
+<%= render(partial: 'apitome/docs/explanation', locals: {explanation: example['resource_explanation']}) unless example['resource_explanation'].nil? %>
+<%= render partial: 'apitome/docs/endpoint',       locals: {method: example['http_method'], endpoint: example['route']} %>
+<%= render partial: 'apitome/docs/params',         locals: {params: example['parameters']} if example['parameters'].size > 0 %>
+
+<% example['requests'].each_with_index do |request, index| %>
+  <div id="<%= "request-#{index}" %>">
+    <h3><%= t(:request, scope: :apitome) %></h3>
+    <div class="request">
+      <% begin %>
+      <%= render partial: 'apitome/docs/route',    locals: {request: request, index: index} %>
+      <%= render partial: 'apitome/docs/headers',  locals: {request: request, index: index, headers: request['request_headers']} %>
+      <%= render partial: 'apitome/docs/query',    locals: {request: request, index: index} unless request['request_query_parameters'].empty? %>
+      <%= render partial: 'apitome/docs/body',     locals: {request: request, index: index, body: request['request_body'], type: request['request_content_type']} if request['request_body'] %>
+      <%= render partial: 'apitome/docs/curl',     locals: {request: request, index: index} if request['curl'] %>
+      <%
+        rescue => e
+          if Apitome.configuration.example_error_handler
+            Apitome.configuration.example_error_handler.call(e, "request", request)
+          else
+            raise
+          end
+        end
+      %>
+    </div>
+
+    <h3><%= t(:response, scope: :apitome) %></h3>
+    <div class="response">
+      <% begin %>
+      <%- if Apitome.configuration.simulated_response %>
+        <%= link_to('Simulated Response', simulated_path(example[:link])) if example[:link].present? %>
+      <%- end %>
+      <%= render partial: 'apitome/docs/response_fields', locals: {params: example['response_fields']} if example['response_fields'].size > 0 %>
+      <%= render partial: 'apitome/docs/status',          locals: {request: request, index: index} %>
+      <%= render partial: 'apitome/docs/headers',         locals: {request: request, index: index, headers: request['response_headers']} %>
+      <%= render partial: 'apitome/docs/body',            locals: {request: request, index: index, body: request['response_body'], type: request['response_content_type']} if request['response_body'] %>
+      <%
+        rescue => e
+          if Apitome.configuration.example_error_handler
+            Apitome.configuration.example_error_handler.call(e, "response", request)
+          else
+            raise
+          end
+        end
+      %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/apitome/docs/_explanation.html.erb
+++ b/app/views/apitome/docs/_explanation.html.erb
@@ -1,0 +1,3 @@
+<div class="explanation">
+  <%= raw rendered_markdown(example['resource_explanation'].strip_heredoc) %>
+</div>


### PR DESCRIPTION
The doc tests can have an explanation that accepts markdown.  The default partials for apitome did not match what rspec_api_documentation generated, so these were needed to fix that functionality.