### PR TITLE
Expose multi-sided card/printing data

### DIFF
--- a/app/controllers/api/v3/public/card_faces_controller.rb
+++ b/app/controllers/api/v3/public/card_faces_controller.rb
@@ -1,8 +1,0 @@
-module API
-  module V3
-    module Public
-      class Api::V3::Public::CardFacesController < JSONAPI::ResourceController
-      end
-    end
-  end
-end

--- a/app/controllers/api/v3/public/card_faces_controller.rb
+++ b/app/controllers/api/v3/public/card_faces_controller.rb
@@ -1,0 +1,8 @@
+module API
+  module V3
+    module Public
+      class Api::V3::Public::CardFacesController < JSONAPI::ResourceController
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/public/printing_faces_controller.rb
+++ b/app/controllers/api/v3/public/printing_faces_controller.rb
@@ -1,8 +1,0 @@
-module API
-  module V3
-    module Public
-      class Api::V3::Public::PrintingFacesController < JSONAPI::ResourceController
-      end
-    end
-  end
-end

--- a/app/controllers/api/v3/public/printing_faces_controller.rb
+++ b/app/controllers/api/v3/public/printing_faces_controller.rb
@@ -1,0 +1,8 @@
+module API
+  module V3
+    module Public
+      class Api::V3::Public::PrintingFacesController < JSONAPI::ResourceController
+      end
+    end
+  end
+end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,6 +5,7 @@ class Card < ApplicationRecord
   belongs_to :faction
   belongs_to :card_type
   has_many :card_card_subtypes
+  has_many :card_faces
   has_many :card_subtypes, :through => :card_card_subtypes
   has_many :printings
   has_many :unified_printings

--- a/app/models/card_card_face.rb
+++ b/app/models/card_card_face.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CardCardFace < ApplicationRecord
+  self.table_name = "cards_card_faces"
+
+  belongs_to :card,
+    :primary_key => :id,
+    :foreign_key => :card_id
+  belongs_to :card_face,
+    :primary_key => :id,
+    :foreign_key => :card_face_id
+  belongs_to :unified_card,
+    :primary_key => :id,
+    :foreign_key => :card_id
+ end

--- a/app/models/card_face.rb
+++ b/app/models/card_face.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CardFace < ApplicationRecord
+  has_one :card_card_face
+  has_one :card, :through => :card_card_face
+  has_one :unified_card, :through => :card_card_face, primary_key: :card_id, foreign_key: :id
+  has_many :card_face_card_subtypes
+  has_many :card_subtypes, :through => :card_face_card_subtypes
+end

--- a/app/models/card_face_card_subtype.rb
+++ b/app/models/card_face_card_subtype.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CardFaceCardSubtype < ApplicationRecord
+  self.table_name = "card_faces_card_subtypes"
+
+  belongs_to :card_face,
+    :primary_key => :id,
+    :foreign_key => :card_face_id
+  belongs_to :card_subtype,
+    :primary_key => :id,
+    :foreign_key => :card_subtype_id
+ end

--- a/app/models/printing.rb
+++ b/app/models/printing.rb
@@ -9,6 +9,7 @@ class Printing < ApplicationRecord
   has_one :side, :through => :card
   has_many :illustrator_printings
   has_many :illustrators, :through => :illustrator_printings
+  has_many :printing_faces
 
   has_many :unified_restrictions, primary_key: :card_id, foreign_key: :card_id
   has_many :card_pool_cards, primary_key: :card_id, foreign_key: :card_id

--- a/app/models/printing_face.rb
+++ b/app/models/printing_face.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PrintingFace < ApplicationRecord
+  has_one :printing_printing_face
+  has_one :printing, :through => :printing_printing_face
+  has_one :unified_printing, :through => :printing_printing_face, primary_key: :printing_id, foreign_key: :id
+  has_many :printing_face_illustrators
+  has_many :illustrators, :through => :printing_face_illustrators
+end

--- a/app/models/printing_face_illustrator.rb
+++ b/app/models/printing_face_illustrator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class PrintingFaceIllustrator < ApplicationRecord
+  self.table_name = "printing_faces_illustrators"
+
+  belongs_to :printing_face,
+    :primary_key => :id,
+    :foreign_key => :printing_face_id
+  belongs_to :illustrator,
+    :primary_key => :id,
+    :foreign_key => :illustrator_id
+ end

--- a/app/models/printing_printing_face.rb
+++ b/app/models/printing_printing_face.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PrintingPrintingFace < ApplicationRecord
+  self.table_name = "printings_printing_faces"
+
+  belongs_to :printing,
+    :primary_key => :id,
+    :foreign_key => :printing_id
+  belongs_to :printing_face,
+    :primary_key => :id,
+    :foreign_key => :printing_face_id
+  belongs_to :unified_printing,
+    :primary_key => :id,
+    :foreign_key => :printing_id
+ end

--- a/app/models/unified_card.rb
+++ b/app/models/unified_card.rb
@@ -13,6 +13,12 @@ class UnifiedCard < ApplicationRecord
 
     has_many :card_subtypes, :through => :card_card_subtypes
 
+    has_many :card_card_faces,
+      :primary_key => :id,
+      :foreign_key => :card_id
+
+    has_many :card_faces, :through => :card_card_faces
+
     has_many :unified_printings,
       :primary_key => :id,
       :foreign_key => :card_id

--- a/app/models/unified_printing.rb
+++ b/app/models/unified_printing.rb
@@ -14,6 +14,8 @@ class UnifiedPrinting < ApplicationRecord
   has_one :side, :through => :card
   has_many :illustrator_printings, primary_key: :id, foreign_key: :printing_id
   has_many :illustrators, :through => :illustrator_printings
+  has_many :printing_printing_faces, :primary_key => :id, :foreign_key => :printing_id
+  has_many :printing_faces, :through => :printing_printing_faces
 
   has_many :unified_restrictions, primary_key: :card_id, foreign_key: :card_id
   has_many :card_pool_cards, primary_key: :card_id, foreign_key: :card_id

--- a/app/resources/api/v3/public/card_face_resource.rb
+++ b/app/resources/api/v3/public/card_face_resource.rb
@@ -1,0 +1,22 @@
+module API
+  module V3
+    module Public
+      class Api::V3::Public::CardFaceResource < JSONAPI::Resource
+        immutable
+
+        attributes :stripped_title, :title, :advancement_requirement
+        attributes :agenda_points, :base_link, :cost, :memory_cost, :strength
+        attributes :stripped_text, :text, :trash_cost, :is_unique
+        attributes :card_subtype_ids, :display_subtypes, :updated_at
+
+        key_type :string
+
+        def card_subtype_ids
+          @model.card_subtypes.map { |s| s.id }
+        end
+
+        has_one :card
+      end
+    end
+  end
+end

--- a/app/resources/api/v3/public/card_resource.rb
+++ b/app/resources/api/v3/public/card_resource.rb
@@ -12,9 +12,10 @@ module API
         attributes :date_release, :restriction_ids, :strength, :stripped_text, :text, :trash_cost, :is_unique
         attributes :card_subtype_ids, :display_subtypes, :attribution, :updated_at
         attributes :format_ids, :card_pool_ids, :snapshot_ids, :card_cycle_ids, :card_set_ids
+        attributes :layout_id
 
         # Synthesized attributes
-        attributes :card_abilities, :latest_printing_id, :restrictions
+        attributes :num_faces, :card_abilities, :latest_printing_id, :restrictions
 
         key_type :string
 
@@ -22,11 +23,16 @@ module API
         has_one :faction
         has_one :card_type
         has_many :card_subtypes
+        has_many :card_faces
         has_many :printings, relation_name: :unified_printings
         has_many :rulings
 
         def latest_printing_id
           @model.printing_ids[0]
+        end
+
+        def num_faces
+          @model.card_faces.length
         end
 
         def packed_restriction_to_map(packed)

--- a/app/resources/api/v3/public/printing_face_resource.rb
+++ b/app/resources/api/v3/public/printing_face_resource.rb
@@ -1,0 +1,19 @@
+module API
+  module V3
+    module Public
+      class Api::V3::Public::PrintingFaceResource < JSONAPI::Resource
+        immutable
+
+        attributes :flavor, :display_illustrators, :copy_quantity, :updated_at
+
+        key_type :string
+
+        def illustrator_ids
+          @model.illustrators.map { |s| s.id }
+        end
+
+        has_one :printing
+      end
+    end
+  end
+end

--- a/app/resources/api/v3/public/printing_resource.rb
+++ b/app/resources/api/v3/public/printing_resource.rb
@@ -21,19 +21,25 @@ module API
         attributes :title, :trash_cost, :printing_ids, :num_printings, :restriction_ids, :in_restriction
         attributes :format_ids, :card_pool_ids, :snapshot_ids
         attributes :card_cycle_ids, :card_set_ids, :attribution
+        attributes :layout_id
 
         # Synthesized attributes
-        attributes :card_abilities, :images, :latest_printing_id, :restrictions
+        attributes :num_faces, :card_abilities, :images, :latest_printing_id, :restrictions
 
         has_one :card, relation_name: :unified_card
         has_one :card_cycle
         has_one :card_set
         has_one :faction
         has_many :illustrators
+        has_many :printing_faces
         has_one :side
 
         def latest_printing_id
           @model.printing_ids[0]
+        end
+
+        def num_faces
+          @model.printing_faces.length
         end
 
         def packed_restriction_to_map(packed)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         jsonapi_resources :formats, only: [:index, :show]
         jsonapi_resources :illustrators, only: [:index, :show]
         jsonapi_resources :printings, only: [:index, :show]
+        jsonapi_resources :printing_faces, only: [:index, :show]
         jsonapi_resources :restrictions, only: [:index, :show]
         jsonapi_resources :rulings, only: [:index]
         jsonapi_resources :sides, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v3 do
       namespace :public, defaults: { format: :json } do
         jsonapi_resources :card_cycles, only: [:index, :show]
+        jsonapi_resources :card_faces, only: [:index, :show]
         jsonapi_resources :card_pools, only: [:index, :show]
         jsonapi_resources :card_set_types, only: [:index, :show]
         jsonapi_resources :card_sets, only: [:index, :show]

--- a/db/migrate/20230522090444_create_card_faces.rb
+++ b/db/migrate/20230522090444_create_card_faces.rb
@@ -27,7 +27,7 @@ class CreateCardFaces < ActiveRecord::Migration[7.0]
     create_table :card_faces_card_subtypes, id: false, force: :cascade do |t|
       t.string :card_face_id, null: false
       t.string :card_subtype_id, null: false
-      t.index [:card_face_id, :card_subtype_id], name: "index_card_faces_card_subtypes_on_card_id_and_card_face_id", unique: true
+      t.index [:card_face_id, :card_subtype_id], name: "index_card_faces_card_subtypes_on_face_id_and_subtype_id", unique: true # shortened name due to limit
     end
   end
 end

--- a/db/migrate/20230522090444_create_card_faces.rb
+++ b/db/migrate/20230522090444_create_card_faces.rb
@@ -1,0 +1,33 @@
+class CreateCardFaces < ActiveRecord::Migration[7.0]
+  def change
+    create_table :card_faces, id: :string do |t|
+      t.string :card_id, null: false
+      t.text :title
+      t.text :stripped_title
+      t.text :base_link
+      t.integer :advancement_requirement
+      t.integer :agenda_points
+      t.integer :cost
+      t.integer :memory_cost
+      t.integer :strength
+      t.text :text
+      t.text :stripped_text
+      t.integer :trash_cost
+      t.boolean :is_unique
+      t.text :display_subtypes
+      t.timestamps
+    end
+
+    create_table :cards_card_faces, id: false, force: :cascade do |t|
+      t.string :card_id, null: false
+      t.string :card_face_id, null: false
+      t.index [:card_id, :card_face_id], name: "index_cards_card_faces_on_card_id_and_card_face_id", unique: true
+    end
+
+    create_table :card_faces_card_subtypes, id: false, force: :cascade do |t|
+      t.string :card_face_id, null: false
+      t.string :card_subtype_id, null: false
+      t.index [:card_face_id, :card_subtype_id], name: "index_card_faces_card_subtypes_on_card_id_and_card_face_id", unique: true
+    end
+  end
+end

--- a/db/migrate/20230522152806_add_layout_id_to_cards.rb
+++ b/db/migrate/20230522152806_add_layout_id_to_cards.rb
@@ -1,0 +1,5 @@
+class AddLayoutIdToCards < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cards, :layout_id, :string
+  end
+end

--- a/db/migrate/20230522153927_update_unified_cards_to_version4.rb
+++ b/db/migrate/20230522153927_update_unified_cards_to_version4.rb
@@ -1,0 +1,5 @@
+class UpdateUnifiedCardsToVersion4 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :unified_cards, materialized: true, version: 4, revert_to_version: 3
+  end
+end

--- a/db/migrate/20230523072820_create_printing_faces.rb
+++ b/db/migrate/20230523072820_create_printing_faces.rb
@@ -1,0 +1,23 @@
+class CreatePrintingFaces < ActiveRecord::Migration[7.0]
+  def change
+    create_table :printing_faces, id: :string do |t|
+      t.string :printing_id, null: false
+      t.text :flavor
+      t.text :display_illustrators
+      t.integer :copy_quantity
+      t.timestamps
+    end
+
+    create_table :printings_printing_faces, id: false, force: :cascade do |t|
+      t.string :printing_id, null: false
+      t.string :printing_face_id, null: false
+      t.index [:printing_id, :printing_face_id], name: "index_printings_printing_faces_on_printing_id_and_face_id", unique: true # shortened name due to limit
+    end
+
+    create_table :printing_faces_illustrators, id: false, force: :cascade do |t|
+      t.string :printing_face_id, null: false
+      t.string :illustrator_id, null: false
+      t.index [:printing_face_id, :illustrator_id], name: "index_printing_faces_illustrators_on_face_id_and_illustrator_id", unique: true # shortened name due to limit
+    end
+  end
+end

--- a/db/migrate/20230523072901_add_layout_id_to_printings.rb
+++ b/db/migrate/20230523072901_add_layout_id_to_printings.rb
@@ -1,0 +1,5 @@
+class AddLayoutIdToPrintings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :printings, :layout_id, :string
+  end
+end

--- a/db/migrate/20230523073031_update_unified_printings_to_version4.rb
+++ b/db/migrate/20230523073031_update_unified_printings_to_version4.rb
@@ -1,0 +1,5 @@
+class UpdateUnifiedPrintingsToVersion4 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :unified_printings, materialized: true, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_165649) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,31 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_165649) do
     t.datetime "updated_at", null: false
     t.date "date_release"
     t.string "legacy_code"
+  end
+
+  create_table "card_faces", id: :string, force: :cascade do |t|
+    t.string "card_id", null: false
+    t.text "title"
+    t.text "stripped_title"
+    t.text "base_link"
+    t.integer "advancement_requirement"
+    t.integer "agenda_points"
+    t.integer "cost"
+    t.integer "memory_cost"
+    t.integer "strength"
+    t.text "text"
+    t.text "stripped_text"
+    t.integer "trash_cost"
+    t.boolean "is_unique"
+    t.text "display_subtypes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "card_faces_card_subtypes", id: false, force: :cascade do |t|
+    t.string "card_face_id", null: false
+    t.string "card_subtype_id", null: false
+    t.index ["card_face_id", "card_subtype_id"], name: "index_card_faces_card_subtypes_on_card_id_and_card_face_id", unique: true
   end
 
   create_table "card_pools", id: :string, force: :cascade do |t|
@@ -116,10 +141,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_165649) do
     t.boolean "rez_effect", default: false
     t.boolean "trash_ability", default: false
     t.string "attribution"
+    t.string "layout_id"
     t.index ["card_type_id"], name: "index_cards_on_card_type_id"
     t.index ["faction_id"], name: "index_cards_on_faction_id"
     t.index ["side_id"], name: "index_cards_on_side_id"
     t.index ["title"], name: "index_cards_unique_title", unique: true
+  end
+
+  create_table "cards_card_faces", id: false, force: :cascade do |t|
+    t.string "card_id", null: false
+    t.string "card_face_id", null: false
+    t.index ["card_id", "card_face_id"], name: "index_cards_card_faces_on_card_id_and_card_face_id", unique: true
   end
 
   create_table "cards_card_subtypes", id: false, force: :cascade do |t|
@@ -340,170 +372,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_165649) do
   add_index "unified_restrictions", ["restriction_id"], name: "index_unified_restrictions_on_restriction_id"
   add_index "unified_restrictions", ["snapshot_id"], name: "index_unified_restrictions_on_snapshot_id"
 
-  create_view "unified_cards", materialized: true, sql_definition: <<-SQL
-      WITH card_cycles_summary AS (
-           SELECT c_1.id,
-              array_agg(cc.id ORDER BY cc.id) AS card_cycle_ids,
-              array_agg(lower(cc.name) ORDER BY (lower(cc.name))) AS card_cycle_names
-             FROM (((cards c_1
-               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
-               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
-               JOIN card_cycles cc ON (((cc.id)::text = cs.card_cycle_id)))
-            GROUP BY c_1.id
-          ), card_sets_summary AS (
-           SELECT c_1.id,
-              array_agg(cs.id ORDER BY cs.id) AS card_set_ids,
-              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS card_set_names
-             FROM ((cards c_1
-               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
-               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
-            GROUP BY c_1.id
-          ), card_subtype_ids AS (
-           SELECT cards_card_subtypes.card_id,
-              array_agg(cards_card_subtypes.card_subtype_id ORDER BY 1::integer) AS card_subtype_ids
-             FROM cards_card_subtypes
-            GROUP BY cards_card_subtypes.card_id
-          ), card_subtype_names AS (
-           SELECT ccs_1.card_id,
-              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS lower_card_subtype_names,
-              array_agg(cs.name ORDER BY cs.name) AS card_subtype_names
-             FROM (cards_card_subtypes ccs_1
-               JOIN card_subtypes cs ON ((ccs_1.card_subtype_id = (cs.id)::text)))
-            GROUP BY ccs_1.card_id
-          ), card_printing_ids AS (
-           SELECT printings.card_id,
-              array_agg(printings.id ORDER BY printings.date_release DESC) AS printing_ids
-             FROM printings
-            GROUP BY printings.card_id
-          ), card_release_dates AS (
-           SELECT printings.card_id,
-              min(printings.date_release) AS date_release
-             FROM printings
-            GROUP BY printings.card_id
-          ), card_restriction_ids AS (
-           SELECT unified_restrictions.card_id,
-              array_agg(unified_restrictions.restriction_id ORDER BY unified_restrictions.restriction_id) AS restriction_ids
-             FROM unified_restrictions
-            WHERE unified_restrictions.in_restriction
-            GROUP BY unified_restrictions.card_id
-          ), restrictions_banned_summary AS (
-           SELECT restrictions_cards_banned.card_id,
-              array_agg(restrictions_cards_banned.restriction_id ORDER BY restrictions_cards_banned.restriction_id) AS restrictions_banned
-             FROM restrictions_cards_banned
-            GROUP BY restrictions_cards_banned.card_id
-          ), restrictions_global_penalty_summary AS (
-           SELECT restrictions_cards_global_penalty.card_id,
-              array_agg(restrictions_cards_global_penalty.restriction_id ORDER BY restrictions_cards_global_penalty.restriction_id) AS restrictions_global_penalty
-             FROM restrictions_cards_global_penalty
-            GROUP BY restrictions_cards_global_penalty.card_id
-          ), restrictions_points_summary AS (
-           SELECT restrictions_cards_points.card_id,
-              array_agg(concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text) ORDER BY (concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text))) AS restrictions_points
-             FROM restrictions_cards_points
-            GROUP BY restrictions_cards_points.card_id
-          ), restrictions_restricted_summary AS (
-           SELECT restrictions_cards_restricted.card_id,
-              array_agg(restrictions_cards_restricted.restriction_id ORDER BY restrictions_cards_restricted.restriction_id) AS restrictions_restricted
-             FROM restrictions_cards_restricted
-            GROUP BY restrictions_cards_restricted.card_id
-          ), restrictions_universal_faction_cost_summary AS (
-           SELECT restrictions_cards_universal_faction_cost.card_id,
-              array_agg(concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text) ORDER BY (concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text))) AS restrictions_universal_faction_cost
-             FROM restrictions_cards_universal_faction_cost
-            GROUP BY restrictions_cards_universal_faction_cost.card_id
-          ), format_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.format_id ORDER BY s_1.format_id) AS format_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          ), card_pool_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.card_pool_id ORDER BY s_1.card_pool_id) AS card_pool_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          ), snapshot_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.id ORDER BY s_1.id) AS snapshot_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          )
-   SELECT c.id,
-      c.title,
-      c.stripped_title,
-      c.card_type_id,
-      c.side_id,
-      c.faction_id,
-      c.advancement_requirement,
-      c.agenda_points,
-      c.base_link,
-      c.cost,
-      c.deck_limit,
-      c.influence_cost,
-      c.influence_limit,
-      c.memory_cost,
-      c.minimum_deck_size,
-      c.strength,
-      c.stripped_text,
-      c.text,
-      c.trash_cost,
-      c.is_unique,
-      c.display_subtypes,
-      c.attribution,
-      c.created_at,
-      c.updated_at,
-      c.additional_cost,
-      c.advanceable,
-      c.gains_subroutines,
-      c.interrupt,
-      c.link_provided,
-      c.mu_provided,
-      c.num_printed_subroutines,
-      c.on_encounter_effect,
-      c.performs_trace,
-      c.recurring_credits_provided,
-      c.rez_effect,
-      c.trash_ability,
-      COALESCE(csi.card_subtype_ids, ARRAY[]::text[]) AS card_subtype_ids,
-      COALESCE(csn.lower_card_subtype_names, ARRAY[]::text[]) AS lower_card_subtype_names,
-      COALESCE(csn.card_subtype_names, ARRAY[]::text[]) AS card_subtype_names,
-      p.printing_ids,
-      array_length(p.printing_ids, 1) AS num_printings,
-      ccs.card_cycle_ids,
-      ccs.card_cycle_names,
-      css.card_set_ids,
-      css.card_set_names,
-      COALESCE(r.restriction_ids, (ARRAY[]::text[])::character varying[]) AS restriction_ids,
-      (r.restriction_ids IS NOT NULL) AS in_restriction,
-      COALESCE(r_b.restrictions_banned, ARRAY[]::text[]) AS restrictions_banned,
-      COALESCE(r_g_p.restrictions_global_penalty, ARRAY[]::text[]) AS restrictions_global_penalty,
-      COALESCE(r_p.restrictions_points, ARRAY[]::text[]) AS restrictions_points,
-      COALESCE(r_r.restrictions_restricted, ARRAY[]::text[]) AS restrictions_restricted,
-      COALESCE(r_u_f_c.restrictions_universal_faction_cost, ARRAY[]::text[]) AS restrictions_universal_faction_cost,
-      COALESCE(f.format_ids, ARRAY[]::text[]) AS format_ids,
-      COALESCE(cpc.card_pool_ids, ARRAY[]::text[]) AS card_pool_ids,
-      COALESCE(s.snapshot_ids, (ARRAY[]::text[])::character varying[]) AS snapshot_ids,
-      crd.date_release
-     FROM (((((((((((((((cards c
-       JOIN card_printing_ids p ON (((c.id)::text = p.card_id)))
-       JOIN card_cycles_summary ccs ON (((c.id)::text = (ccs.id)::text)))
-       JOIN card_sets_summary css ON (((c.id)::text = (css.id)::text)))
-       LEFT JOIN card_subtype_ids csi ON (((c.id)::text = csi.card_id)))
-       LEFT JOIN card_subtype_names csn ON (((c.id)::text = csn.card_id)))
-       LEFT JOIN card_restriction_ids r ON (((c.id)::text = (r.card_id)::text)))
-       LEFT JOIN restrictions_banned_summary r_b ON (((c.id)::text = r_b.card_id)))
-       LEFT JOIN restrictions_global_penalty_summary r_g_p ON (((c.id)::text = r_g_p.card_id)))
-       LEFT JOIN restrictions_points_summary r_p ON (((c.id)::text = r_p.card_id)))
-       LEFT JOIN restrictions_restricted_summary r_r ON (((c.id)::text = r_r.card_id)))
-       LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON (((c.id)::text = r_u_f_c.card_id)))
-       LEFT JOIN format_ids f ON (((c.id)::text = f.card_id)))
-       LEFT JOIN card_pool_ids cpc ON (((c.id)::text = cpc.card_id)))
-       LEFT JOIN snapshot_ids s ON (((c.id)::text = s.card_id)))
-       LEFT JOIN card_release_dates crd ON (((c.id)::text = crd.card_id)))
-    GROUP BY c.id, c.title, c.stripped_title, c.card_type_id, c.side_id, c.faction_id, c.advancement_requirement, c.agenda_points, c.base_link, c.cost, c.deck_limit, c.influence_cost, c.influence_limit, c.memory_cost, c.minimum_deck_size, c.strength, c.stripped_text, c.text, c.trash_cost, c.is_unique, c.display_subtypes, c.attribution, c.created_at, c.updated_at, c.additional_cost, c.advanceable, c.gains_subroutines, c.interrupt, c.link_provided, c.mu_provided, c.num_printed_subroutines, c.on_encounter_effect, c.performs_trace, c.recurring_credits_provided, c.rez_effect, c.trash_ability, csi.card_subtype_ids, csn.lower_card_subtype_names, csn.card_subtype_names, p.printing_ids, ccs.card_cycle_ids, ccs.card_cycle_names, css.card_set_ids, css.card_set_names, r.restriction_ids, r_b.restrictions_banned, r_g_p.restrictions_global_penalty, r_p.restrictions_points, r_r.restrictions_restricted, r_u_f_c.restrictions_universal_faction_cost, f.format_ids, cpc.card_pool_ids, s.snapshot_ids, crd.date_release;
-  SQL
   create_view "unified_printings", materialized: true, sql_definition: <<-SQL
       WITH card_cycles_summary AS (
            SELECT c_1.id,
@@ -682,5 +550,170 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_165649) do
        LEFT JOIN format_ids f ON ((p.card_id = f.card_id)))
        LEFT JOIN card_pool_ids cpc ON ((p.card_id = cpc.card_id)))
        LEFT JOIN snapshot_ids s ON ((p.card_id = s.card_id)));
+  SQL
+  create_view "unified_cards", materialized: true, sql_definition: <<-SQL
+      WITH card_cycles_summary AS (
+           SELECT c_1.id,
+              array_agg(cc.id ORDER BY cc.id) AS card_cycle_ids,
+              array_agg(lower(cc.name) ORDER BY (lower(cc.name))) AS card_cycle_names
+             FROM (((cards c_1
+               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
+               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
+               JOIN card_cycles cc ON (((cc.id)::text = cs.card_cycle_id)))
+            GROUP BY c_1.id
+          ), card_sets_summary AS (
+           SELECT c_1.id,
+              array_agg(cs.id ORDER BY cs.id) AS card_set_ids,
+              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS card_set_names
+             FROM ((cards c_1
+               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
+               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
+            GROUP BY c_1.id
+          ), card_subtype_ids AS (
+           SELECT cards_card_subtypes.card_id,
+              array_agg(cards_card_subtypes.card_subtype_id ORDER BY 1::integer) AS card_subtype_ids
+             FROM cards_card_subtypes
+            GROUP BY cards_card_subtypes.card_id
+          ), card_subtype_names AS (
+           SELECT ccs_1.card_id,
+              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS lower_card_subtype_names,
+              array_agg(cs.name ORDER BY cs.name) AS card_subtype_names
+             FROM (cards_card_subtypes ccs_1
+               JOIN card_subtypes cs ON ((ccs_1.card_subtype_id = (cs.id)::text)))
+            GROUP BY ccs_1.card_id
+          ), card_printing_ids AS (
+           SELECT printings.card_id,
+              array_agg(printings.id ORDER BY printings.date_release DESC) AS printing_ids
+             FROM printings
+            GROUP BY printings.card_id
+          ), card_release_dates AS (
+           SELECT printings.card_id,
+              min(printings.date_release) AS date_release
+             FROM printings
+            GROUP BY printings.card_id
+          ), card_restriction_ids AS (
+           SELECT unified_restrictions.card_id,
+              array_agg(unified_restrictions.restriction_id ORDER BY unified_restrictions.restriction_id) AS restriction_ids
+             FROM unified_restrictions
+            WHERE unified_restrictions.in_restriction
+            GROUP BY unified_restrictions.card_id
+          ), restrictions_banned_summary AS (
+           SELECT restrictions_cards_banned.card_id,
+              array_agg(restrictions_cards_banned.restriction_id ORDER BY restrictions_cards_banned.restriction_id) AS restrictions_banned
+             FROM restrictions_cards_banned
+            GROUP BY restrictions_cards_banned.card_id
+          ), restrictions_global_penalty_summary AS (
+           SELECT restrictions_cards_global_penalty.card_id,
+              array_agg(restrictions_cards_global_penalty.restriction_id ORDER BY restrictions_cards_global_penalty.restriction_id) AS restrictions_global_penalty
+             FROM restrictions_cards_global_penalty
+            GROUP BY restrictions_cards_global_penalty.card_id
+          ), restrictions_points_summary AS (
+           SELECT restrictions_cards_points.card_id,
+              array_agg(concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text) ORDER BY (concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text))) AS restrictions_points
+             FROM restrictions_cards_points
+            GROUP BY restrictions_cards_points.card_id
+          ), restrictions_restricted_summary AS (
+           SELECT restrictions_cards_restricted.card_id,
+              array_agg(restrictions_cards_restricted.restriction_id ORDER BY restrictions_cards_restricted.restriction_id) AS restrictions_restricted
+             FROM restrictions_cards_restricted
+            GROUP BY restrictions_cards_restricted.card_id
+          ), restrictions_universal_faction_cost_summary AS (
+           SELECT restrictions_cards_universal_faction_cost.card_id,
+              array_agg(concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text) ORDER BY (concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text))) AS restrictions_universal_faction_cost
+             FROM restrictions_cards_universal_faction_cost
+            GROUP BY restrictions_cards_universal_faction_cost.card_id
+          ), format_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.format_id ORDER BY s_1.format_id) AS format_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          ), card_pool_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.card_pool_id ORDER BY s_1.card_pool_id) AS card_pool_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          ), snapshot_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.id ORDER BY s_1.id) AS snapshot_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          )
+   SELECT c.id,
+      c.title,
+      c.stripped_title,
+      c.card_type_id,
+      c.side_id,
+      c.faction_id,
+      c.advancement_requirement,
+      c.agenda_points,
+      c.base_link,
+      c.cost,
+      c.deck_limit,
+      c.influence_cost,
+      c.influence_limit,
+      c.memory_cost,
+      c.minimum_deck_size,
+      c.strength,
+      c.stripped_text,
+      c.text,
+      c.trash_cost,
+      c.is_unique,
+      c.display_subtypes,
+      c.attribution,
+      c.layout_id,
+      c.created_at,
+      c.updated_at,
+      c.additional_cost,
+      c.advanceable,
+      c.gains_subroutines,
+      c.interrupt,
+      c.link_provided,
+      c.mu_provided,
+      c.num_printed_subroutines,
+      c.on_encounter_effect,
+      c.performs_trace,
+      c.recurring_credits_provided,
+      c.rez_effect,
+      c.trash_ability,
+      COALESCE(csi.card_subtype_ids, ARRAY[]::text[]) AS card_subtype_ids,
+      COALESCE(csn.lower_card_subtype_names, ARRAY[]::text[]) AS lower_card_subtype_names,
+      COALESCE(csn.card_subtype_names, ARRAY[]::text[]) AS card_subtype_names,
+      p.printing_ids,
+      array_length(p.printing_ids, 1) AS num_printings,
+      ccs.card_cycle_ids,
+      ccs.card_cycle_names,
+      css.card_set_ids,
+      css.card_set_names,
+      COALESCE(r.restriction_ids, (ARRAY[]::text[])::character varying[]) AS restriction_ids,
+      (r.restriction_ids IS NOT NULL) AS in_restriction,
+      COALESCE(r_b.restrictions_banned, ARRAY[]::text[]) AS restrictions_banned,
+      COALESCE(r_g_p.restrictions_global_penalty, ARRAY[]::text[]) AS restrictions_global_penalty,
+      COALESCE(r_p.restrictions_points, ARRAY[]::text[]) AS restrictions_points,
+      COALESCE(r_r.restrictions_restricted, ARRAY[]::text[]) AS restrictions_restricted,
+      COALESCE(r_u_f_c.restrictions_universal_faction_cost, ARRAY[]::text[]) AS restrictions_universal_faction_cost,
+      COALESCE(f.format_ids, ARRAY[]::text[]) AS format_ids,
+      COALESCE(cpc.card_pool_ids, ARRAY[]::text[]) AS card_pool_ids,
+      COALESCE(s.snapshot_ids, (ARRAY[]::text[])::character varying[]) AS snapshot_ids,
+      crd.date_release
+     FROM (((((((((((((((cards c
+       JOIN card_printing_ids p ON (((c.id)::text = p.card_id)))
+       JOIN card_cycles_summary ccs ON (((c.id)::text = (ccs.id)::text)))
+       JOIN card_sets_summary css ON (((c.id)::text = (css.id)::text)))
+       LEFT JOIN card_subtype_ids csi ON (((c.id)::text = csi.card_id)))
+       LEFT JOIN card_subtype_names csn ON (((c.id)::text = csn.card_id)))
+       LEFT JOIN card_restriction_ids r ON (((c.id)::text = (r.card_id)::text)))
+       LEFT JOIN restrictions_banned_summary r_b ON (((c.id)::text = r_b.card_id)))
+       LEFT JOIN restrictions_global_penalty_summary r_g_p ON (((c.id)::text = r_g_p.card_id)))
+       LEFT JOIN restrictions_points_summary r_p ON (((c.id)::text = r_p.card_id)))
+       LEFT JOIN restrictions_restricted_summary r_r ON (((c.id)::text = r_r.card_id)))
+       LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON (((c.id)::text = r_u_f_c.card_id)))
+       LEFT JOIN format_ids f ON (((c.id)::text = f.card_id)))
+       LEFT JOIN card_pool_ids cpc ON (((c.id)::text = cpc.card_id)))
+       LEFT JOIN snapshot_ids s ON (((c.id)::text = s.card_id)))
+       LEFT JOIN card_release_dates crd ON (((c.id)::text = crd.card_id)))
+    GROUP BY c.id, c.title, c.stripped_title, c.card_type_id, c.side_id, c.faction_id, c.advancement_requirement, c.agenda_points, c.base_link, c.cost, c.deck_limit, c.influence_cost, c.influence_limit, c.memory_cost, c.minimum_deck_size, c.strength, c.stripped_text, c.text, c.trash_cost, c.is_unique, c.display_subtypes, c.attribution, c.created_at, c.updated_at, c.additional_cost, c.advanceable, c.gains_subroutines, c.interrupt, c.link_provided, c.mu_provided, c.num_printed_subroutines, c.on_encounter_effect, c.performs_trace, c.recurring_credits_provided, c.rez_effect, c.trash_ability, csi.card_subtype_ids, csn.lower_card_subtype_names, csn.card_subtype_names, p.printing_ids, ccs.card_cycle_ids, ccs.card_cycle_names, css.card_set_ids, css.card_set_names, r.restriction_ids, r_b.restrictions_banned, r_g_p.restrictions_global_penalty, r_p.restrictions_points, r_r.restrictions_restricted, r_u_f_c.restrictions_universal_faction_cost, f.format_ids, cpc.card_pool_ids, s.snapshot_ids, crd.date_release;
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
   create_table "card_faces_card_subtypes", id: false, force: :cascade do |t|
     t.string "card_face_id", null: false
     t.string "card_subtype_id", null: false
-    t.index ["card_face_id", "card_subtype_id"], name: "index_card_faces_card_subtypes_on_card_id_and_card_face_id", unique: true
+    t.index ["card_face_id", "card_subtype_id"], name: "index_card_faces_card_subtypes_on_face_id_and_subtype_id", unique: true
   end
 
   create_table "card_pools", id: :string, force: :cascade do |t|
@@ -403,6 +403,171 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
   add_index "unified_restrictions", ["restriction_id"], name: "index_unified_restrictions_on_restriction_id"
   add_index "unified_restrictions", ["snapshot_id"], name: "index_unified_restrictions_on_snapshot_id"
 
+  create_view "unified_cards", materialized: true, sql_definition: <<-SQL
+      WITH card_cycles_summary AS (
+           SELECT c_1.id,
+              array_agg(cc.id ORDER BY cc.id) AS card_cycle_ids,
+              array_agg(lower(cc.name) ORDER BY (lower(cc.name))) AS card_cycle_names
+             FROM (((cards c_1
+               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
+               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
+               JOIN card_cycles cc ON (((cc.id)::text = cs.card_cycle_id)))
+            GROUP BY c_1.id
+          ), card_sets_summary AS (
+           SELECT c_1.id,
+              array_agg(cs.id ORDER BY cs.id) AS card_set_ids,
+              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS card_set_names
+             FROM ((cards c_1
+               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
+               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
+            GROUP BY c_1.id
+          ), card_subtype_ids AS (
+           SELECT cards_card_subtypes.card_id,
+              array_agg(cards_card_subtypes.card_subtype_id ORDER BY 1::integer) AS card_subtype_ids
+             FROM cards_card_subtypes
+            GROUP BY cards_card_subtypes.card_id
+          ), card_subtype_names AS (
+           SELECT ccs_1.card_id,
+              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS lower_card_subtype_names,
+              array_agg(cs.name ORDER BY cs.name) AS card_subtype_names
+             FROM (cards_card_subtypes ccs_1
+               JOIN card_subtypes cs ON ((ccs_1.card_subtype_id = (cs.id)::text)))
+            GROUP BY ccs_1.card_id
+          ), card_printing_ids AS (
+           SELECT printings.card_id,
+              array_agg(printings.id ORDER BY printings.date_release DESC) AS printing_ids
+             FROM printings
+            GROUP BY printings.card_id
+          ), card_release_dates AS (
+           SELECT printings.card_id,
+              min(printings.date_release) AS date_release
+             FROM printings
+            GROUP BY printings.card_id
+          ), card_restriction_ids AS (
+           SELECT unified_restrictions.card_id,
+              array_agg(unified_restrictions.restriction_id ORDER BY unified_restrictions.restriction_id) AS restriction_ids
+             FROM unified_restrictions
+            WHERE unified_restrictions.in_restriction
+            GROUP BY unified_restrictions.card_id
+          ), restrictions_banned_summary AS (
+           SELECT restrictions_cards_banned.card_id,
+              array_agg(restrictions_cards_banned.restriction_id ORDER BY restrictions_cards_banned.restriction_id) AS restrictions_banned
+             FROM restrictions_cards_banned
+            GROUP BY restrictions_cards_banned.card_id
+          ), restrictions_global_penalty_summary AS (
+           SELECT restrictions_cards_global_penalty.card_id,
+              array_agg(restrictions_cards_global_penalty.restriction_id ORDER BY restrictions_cards_global_penalty.restriction_id) AS restrictions_global_penalty
+             FROM restrictions_cards_global_penalty
+            GROUP BY restrictions_cards_global_penalty.card_id
+          ), restrictions_points_summary AS (
+           SELECT restrictions_cards_points.card_id,
+              array_agg(concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text) ORDER BY (concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text))) AS restrictions_points
+             FROM restrictions_cards_points
+            GROUP BY restrictions_cards_points.card_id
+          ), restrictions_restricted_summary AS (
+           SELECT restrictions_cards_restricted.card_id,
+              array_agg(restrictions_cards_restricted.restriction_id ORDER BY restrictions_cards_restricted.restriction_id) AS restrictions_restricted
+             FROM restrictions_cards_restricted
+            GROUP BY restrictions_cards_restricted.card_id
+          ), restrictions_universal_faction_cost_summary AS (
+           SELECT restrictions_cards_universal_faction_cost.card_id,
+              array_agg(concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text) ORDER BY (concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text))) AS restrictions_universal_faction_cost
+             FROM restrictions_cards_universal_faction_cost
+            GROUP BY restrictions_cards_universal_faction_cost.card_id
+          ), format_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.format_id ORDER BY s_1.format_id) AS format_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          ), card_pool_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.card_pool_id ORDER BY s_1.card_pool_id) AS card_pool_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          ), snapshot_ids AS (
+           SELECT cpc_1.card_id,
+              array_agg(DISTINCT s_1.id ORDER BY s_1.id) AS snapshot_ids
+             FROM (card_pools_cards cpc_1
+               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
+            GROUP BY cpc_1.card_id
+          )
+   SELECT c.id,
+      c.title,
+      c.stripped_title,
+      c.card_type_id,
+      c.side_id,
+      c.faction_id,
+      c.advancement_requirement,
+      c.agenda_points,
+      c.base_link,
+      c.cost,
+      c.deck_limit,
+      c.influence_cost,
+      c.influence_limit,
+      c.memory_cost,
+      c.minimum_deck_size,
+      c.strength,
+      c.stripped_text,
+      c.text,
+      c.trash_cost,
+      c.is_unique,
+      c.display_subtypes,
+      c.attribution,
+      c.layout_id,
+      c.created_at,
+      c.updated_at,
+      c.additional_cost,
+      c.advanceable,
+      c.gains_subroutines,
+      c.interrupt,
+      c.link_provided,
+      c.mu_provided,
+      c.num_printed_subroutines,
+      c.on_encounter_effect,
+      c.performs_trace,
+      c.recurring_credits_provided,
+      c.rez_effect,
+      c.trash_ability,
+      COALESCE(csi.card_subtype_ids, ARRAY[]::text[]) AS card_subtype_ids,
+      COALESCE(csn.lower_card_subtype_names, ARRAY[]::text[]) AS lower_card_subtype_names,
+      COALESCE(csn.card_subtype_names, ARRAY[]::text[]) AS card_subtype_names,
+      p.printing_ids,
+      array_length(p.printing_ids, 1) AS num_printings,
+      ccs.card_cycle_ids,
+      ccs.card_cycle_names,
+      css.card_set_ids,
+      css.card_set_names,
+      COALESCE(r.restriction_ids, (ARRAY[]::text[])::character varying[]) AS restriction_ids,
+      (r.restriction_ids IS NOT NULL) AS in_restriction,
+      COALESCE(r_b.restrictions_banned, ARRAY[]::text[]) AS restrictions_banned,
+      COALESCE(r_g_p.restrictions_global_penalty, ARRAY[]::text[]) AS restrictions_global_penalty,
+      COALESCE(r_p.restrictions_points, ARRAY[]::text[]) AS restrictions_points,
+      COALESCE(r_r.restrictions_restricted, ARRAY[]::text[]) AS restrictions_restricted,
+      COALESCE(r_u_f_c.restrictions_universal_faction_cost, ARRAY[]::text[]) AS restrictions_universal_faction_cost,
+      COALESCE(f.format_ids, ARRAY[]::text[]) AS format_ids,
+      COALESCE(cpc.card_pool_ids, ARRAY[]::text[]) AS card_pool_ids,
+      COALESCE(s.snapshot_ids, (ARRAY[]::text[])::character varying[]) AS snapshot_ids,
+      crd.date_release
+     FROM (((((((((((((((cards c
+       JOIN card_printing_ids p ON (((c.id)::text = p.card_id)))
+       JOIN card_cycles_summary ccs ON (((c.id)::text = (ccs.id)::text)))
+       JOIN card_sets_summary css ON (((c.id)::text = (css.id)::text)))
+       LEFT JOIN card_subtype_ids csi ON (((c.id)::text = csi.card_id)))
+       LEFT JOIN card_subtype_names csn ON (((c.id)::text = csn.card_id)))
+       LEFT JOIN card_restriction_ids r ON (((c.id)::text = (r.card_id)::text)))
+       LEFT JOIN restrictions_banned_summary r_b ON (((c.id)::text = r_b.card_id)))
+       LEFT JOIN restrictions_global_penalty_summary r_g_p ON (((c.id)::text = r_g_p.card_id)))
+       LEFT JOIN restrictions_points_summary r_p ON (((c.id)::text = r_p.card_id)))
+       LEFT JOIN restrictions_restricted_summary r_r ON (((c.id)::text = r_r.card_id)))
+       LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON (((c.id)::text = r_u_f_c.card_id)))
+       LEFT JOIN format_ids f ON (((c.id)::text = f.card_id)))
+       LEFT JOIN card_pool_ids cpc ON (((c.id)::text = cpc.card_id)))
+       LEFT JOIN snapshot_ids s ON (((c.id)::text = s.card_id)))
+       LEFT JOIN card_release_dates crd ON (((c.id)::text = crd.card_id)))
+    GROUP BY c.id, c.title, c.stripped_title, c.card_type_id, c.side_id, c.faction_id, c.advancement_requirement, c.agenda_points, c.base_link, c.cost, c.deck_limit, c.influence_cost, c.influence_limit, c.memory_cost, c.minimum_deck_size, c.strength, c.stripped_text, c.text, c.trash_cost, c.is_unique, c.display_subtypes, c.attribution, c.created_at, c.updated_at, c.additional_cost, c.advanceable, c.gains_subroutines, c.interrupt, c.link_provided, c.mu_provided, c.num_printed_subroutines, c.on_encounter_effect, c.performs_trace, c.recurring_credits_provided, c.rez_effect, c.trash_ability, csi.card_subtype_ids, csn.lower_card_subtype_names, csn.card_subtype_names, p.printing_ids, ccs.card_cycle_ids, ccs.card_cycle_names, css.card_set_ids, css.card_set_names, r.restriction_ids, r_b.restrictions_banned, r_g_p.restrictions_global_penalty, r_p.restrictions_points, r_r.restrictions_restricted, r_u_f_c.restrictions_universal_faction_cost, f.format_ids, cpc.card_pool_ids, s.snapshot_ids, crd.date_release;
+  SQL
   create_view "unified_printings", materialized: true, sql_definition: <<-SQL
       WITH card_cycles_summary AS (
            SELECT c_1.id,
@@ -581,170 +746,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
        LEFT JOIN format_ids f ON ((p.card_id = f.card_id)))
        LEFT JOIN card_pool_ids cpc ON ((p.card_id = cpc.card_id)))
        LEFT JOIN snapshot_ids s ON ((p.card_id = s.card_id)));
-  SQL
-  create_view "unified_cards", materialized: true, sql_definition: <<-SQL
-      WITH card_cycles_summary AS (
-           SELECT c_1.id,
-              array_agg(cc.id ORDER BY cc.id) AS card_cycle_ids,
-              array_agg(lower(cc.name) ORDER BY (lower(cc.name))) AS card_cycle_names
-             FROM (((cards c_1
-               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
-               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
-               JOIN card_cycles cc ON (((cc.id)::text = cs.card_cycle_id)))
-            GROUP BY c_1.id
-          ), card_sets_summary AS (
-           SELECT c_1.id,
-              array_agg(cs.id ORDER BY cs.id) AS card_set_ids,
-              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS card_set_names
-             FROM ((cards c_1
-               JOIN printings p_1 ON (((c_1.id)::text = p_1.card_id)))
-               JOIN card_sets cs ON ((p_1.card_set_id = (cs.id)::text)))
-            GROUP BY c_1.id
-          ), card_subtype_ids AS (
-           SELECT cards_card_subtypes.card_id,
-              array_agg(cards_card_subtypes.card_subtype_id ORDER BY 1::integer) AS card_subtype_ids
-             FROM cards_card_subtypes
-            GROUP BY cards_card_subtypes.card_id
-          ), card_subtype_names AS (
-           SELECT ccs_1.card_id,
-              array_agg(lower(cs.name) ORDER BY (lower(cs.name))) AS lower_card_subtype_names,
-              array_agg(cs.name ORDER BY cs.name) AS card_subtype_names
-             FROM (cards_card_subtypes ccs_1
-               JOIN card_subtypes cs ON ((ccs_1.card_subtype_id = (cs.id)::text)))
-            GROUP BY ccs_1.card_id
-          ), card_printing_ids AS (
-           SELECT printings.card_id,
-              array_agg(printings.id ORDER BY printings.date_release DESC) AS printing_ids
-             FROM printings
-            GROUP BY printings.card_id
-          ), card_release_dates AS (
-           SELECT printings.card_id,
-              min(printings.date_release) AS date_release
-             FROM printings
-            GROUP BY printings.card_id
-          ), card_restriction_ids AS (
-           SELECT unified_restrictions.card_id,
-              array_agg(unified_restrictions.restriction_id ORDER BY unified_restrictions.restriction_id) AS restriction_ids
-             FROM unified_restrictions
-            WHERE unified_restrictions.in_restriction
-            GROUP BY unified_restrictions.card_id
-          ), restrictions_banned_summary AS (
-           SELECT restrictions_cards_banned.card_id,
-              array_agg(restrictions_cards_banned.restriction_id ORDER BY restrictions_cards_banned.restriction_id) AS restrictions_banned
-             FROM restrictions_cards_banned
-            GROUP BY restrictions_cards_banned.card_id
-          ), restrictions_global_penalty_summary AS (
-           SELECT restrictions_cards_global_penalty.card_id,
-              array_agg(restrictions_cards_global_penalty.restriction_id ORDER BY restrictions_cards_global_penalty.restriction_id) AS restrictions_global_penalty
-             FROM restrictions_cards_global_penalty
-            GROUP BY restrictions_cards_global_penalty.card_id
-          ), restrictions_points_summary AS (
-           SELECT restrictions_cards_points.card_id,
-              array_agg(concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text) ORDER BY (concat(restrictions_cards_points.restriction_id, '=', (restrictions_cards_points.value)::text))) AS restrictions_points
-             FROM restrictions_cards_points
-            GROUP BY restrictions_cards_points.card_id
-          ), restrictions_restricted_summary AS (
-           SELECT restrictions_cards_restricted.card_id,
-              array_agg(restrictions_cards_restricted.restriction_id ORDER BY restrictions_cards_restricted.restriction_id) AS restrictions_restricted
-             FROM restrictions_cards_restricted
-            GROUP BY restrictions_cards_restricted.card_id
-          ), restrictions_universal_faction_cost_summary AS (
-           SELECT restrictions_cards_universal_faction_cost.card_id,
-              array_agg(concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text) ORDER BY (concat(restrictions_cards_universal_faction_cost.restriction_id, '=', (restrictions_cards_universal_faction_cost.value)::text))) AS restrictions_universal_faction_cost
-             FROM restrictions_cards_universal_faction_cost
-            GROUP BY restrictions_cards_universal_faction_cost.card_id
-          ), format_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.format_id ORDER BY s_1.format_id) AS format_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          ), card_pool_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.card_pool_id ORDER BY s_1.card_pool_id) AS card_pool_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          ), snapshot_ids AS (
-           SELECT cpc_1.card_id,
-              array_agg(DISTINCT s_1.id ORDER BY s_1.id) AS snapshot_ids
-             FROM (card_pools_cards cpc_1
-               JOIN snapshots s_1 ON ((cpc_1.card_pool_id = s_1.card_pool_id)))
-            GROUP BY cpc_1.card_id
-          )
-   SELECT c.id,
-      c.title,
-      c.stripped_title,
-      c.card_type_id,
-      c.side_id,
-      c.faction_id,
-      c.advancement_requirement,
-      c.agenda_points,
-      c.base_link,
-      c.cost,
-      c.deck_limit,
-      c.influence_cost,
-      c.influence_limit,
-      c.memory_cost,
-      c.minimum_deck_size,
-      c.strength,
-      c.stripped_text,
-      c.text,
-      c.trash_cost,
-      c.is_unique,
-      c.display_subtypes,
-      c.attribution,
-      c.layout_id,
-      c.created_at,
-      c.updated_at,
-      c.additional_cost,
-      c.advanceable,
-      c.gains_subroutines,
-      c.interrupt,
-      c.link_provided,
-      c.mu_provided,
-      c.num_printed_subroutines,
-      c.on_encounter_effect,
-      c.performs_trace,
-      c.recurring_credits_provided,
-      c.rez_effect,
-      c.trash_ability,
-      COALESCE(csi.card_subtype_ids, ARRAY[]::text[]) AS card_subtype_ids,
-      COALESCE(csn.lower_card_subtype_names, ARRAY[]::text[]) AS lower_card_subtype_names,
-      COALESCE(csn.card_subtype_names, ARRAY[]::text[]) AS card_subtype_names,
-      p.printing_ids,
-      array_length(p.printing_ids, 1) AS num_printings,
-      ccs.card_cycle_ids,
-      ccs.card_cycle_names,
-      css.card_set_ids,
-      css.card_set_names,
-      COALESCE(r.restriction_ids, (ARRAY[]::text[])::character varying[]) AS restriction_ids,
-      (r.restriction_ids IS NOT NULL) AS in_restriction,
-      COALESCE(r_b.restrictions_banned, ARRAY[]::text[]) AS restrictions_banned,
-      COALESCE(r_g_p.restrictions_global_penalty, ARRAY[]::text[]) AS restrictions_global_penalty,
-      COALESCE(r_p.restrictions_points, ARRAY[]::text[]) AS restrictions_points,
-      COALESCE(r_r.restrictions_restricted, ARRAY[]::text[]) AS restrictions_restricted,
-      COALESCE(r_u_f_c.restrictions_universal_faction_cost, ARRAY[]::text[]) AS restrictions_universal_faction_cost,
-      COALESCE(f.format_ids, ARRAY[]::text[]) AS format_ids,
-      COALESCE(cpc.card_pool_ids, ARRAY[]::text[]) AS card_pool_ids,
-      COALESCE(s.snapshot_ids, (ARRAY[]::text[])::character varying[]) AS snapshot_ids,
-      crd.date_release
-     FROM (((((((((((((((cards c
-       JOIN card_printing_ids p ON (((c.id)::text = p.card_id)))
-       JOIN card_cycles_summary ccs ON (((c.id)::text = (ccs.id)::text)))
-       JOIN card_sets_summary css ON (((c.id)::text = (css.id)::text)))
-       LEFT JOIN card_subtype_ids csi ON (((c.id)::text = csi.card_id)))
-       LEFT JOIN card_subtype_names csn ON (((c.id)::text = csn.card_id)))
-       LEFT JOIN card_restriction_ids r ON (((c.id)::text = (r.card_id)::text)))
-       LEFT JOIN restrictions_banned_summary r_b ON (((c.id)::text = r_b.card_id)))
-       LEFT JOIN restrictions_global_penalty_summary r_g_p ON (((c.id)::text = r_g_p.card_id)))
-       LEFT JOIN restrictions_points_summary r_p ON (((c.id)::text = r_p.card_id)))
-       LEFT JOIN restrictions_restricted_summary r_r ON (((c.id)::text = r_r.card_id)))
-       LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON (((c.id)::text = r_u_f_c.card_id)))
-       LEFT JOIN format_ids f ON (((c.id)::text = f.card_id)))
-       LEFT JOIN card_pool_ids cpc ON (((c.id)::text = cpc.card_id)))
-       LEFT JOIN snapshot_ids s ON (((c.id)::text = s.card_id)))
-       LEFT JOIN card_release_dates crd ON (((c.id)::text = crd.card_id)))
-    GROUP BY c.id, c.title, c.stripped_title, c.card_type_id, c.side_id, c.faction_id, c.advancement_requirement, c.agenda_points, c.base_link, c.cost, c.deck_limit, c.influence_cost, c.influence_limit, c.memory_cost, c.minimum_deck_size, c.strength, c.stripped_text, c.text, c.trash_cost, c.is_unique, c.display_subtypes, c.attribution, c.created_at, c.updated_at, c.additional_cost, c.advanceable, c.gains_subroutines, c.interrupt, c.link_provided, c.mu_provided, c.num_printed_subroutines, c.on_encounter_effect, c.performs_trace, c.recurring_credits_provided, c.rez_effect, c.trash_ability, csi.card_subtype_ids, csn.lower_card_subtype_names, csn.card_subtype_names, p.printing_ids, ccs.card_cycle_ids, ccs.card_cycle_names, css.card_set_ids, css.card_set_names, r.restriction_ids, r_b.restrictions_banned, r_g_p.restrictions_global_penalty, r_p.restrictions_points, r_r.restrictions_restricted, r_u_f_c.restrictions_universal_faction_cost, f.format_ids, cpc.card_pool_ids, s.snapshot_ids, crd.date_release;
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -212,9 +212,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_073031) do
 
   create_table "printing_faces", id: :string, force: :cascade do |t|
     t.string "printing_id", null: false
-    t.text "printed_text"
-    t.text "stripped_printed_text"
-    t.boolean "printed_is_unique"
     t.text "flavor"
     t.text "display_illustrators"
     t.integer "copy_quantity"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_073031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -210,6 +210,24 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
     t.index ["illustrator_id", "printing_id"], name: "index_illustrators_printings_on_illustrator_id_and_printing_id", unique: true
   end
 
+  create_table "printing_faces", id: :string, force: :cascade do |t|
+    t.string "printing_id", null: false
+    t.text "printed_text"
+    t.text "stripped_printed_text"
+    t.boolean "printed_is_unique"
+    t.text "flavor"
+    t.text "display_illustrators"
+    t.integer "copy_quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "printing_faces_illustrators", id: false, force: :cascade do |t|
+    t.string "printing_face_id", null: false
+    t.string "illustrator_id", null: false
+    t.index ["printing_face_id", "illustrator_id"], name: "index_printing_faces_illustrators_on_face_id_and_illustrator_id", unique: true
+  end
+
   create_table "printings", id: :string, force: :cascade do |t|
     t.text "card_id"
     t.text "card_set_id"
@@ -223,6 +241,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
     t.date "date_release"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "layout_id"
+  end
+
+  create_table "printings_printing_faces", id: false, force: :cascade do |t|
+    t.string "printing_id", null: false
+    t.string "printing_face_id", null: false
+    t.index ["printing_id", "printing_face_id"], name: "index_printings_printing_faces_on_printing_id_and_face_id", unique: true
   end
 
   create_table "restrictions", id: :string, force: :cascade do |t|
@@ -671,6 +696,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_153927) do
       p."position",
       p.quantity,
       p.date_release,
+      c.layout_id,
       p.created_at,
       p.updated_at,
       c.additional_cost,

--- a/db/views/unified_cards_v04.sql
+++ b/db/views/unified_cards_v04.sql
@@ -1,0 +1,325 @@
+WITH card_cycles_summary AS (
+    SELECT
+        c.id,
+        ARRAY_AGG(
+            cc.id ORDER BY cc.id
+        ) as card_cycle_ids,
+        ARRAY_AGG(
+            LOWER(cc.name) ORDER BY LOWER(cc.name)
+        ) as card_cycle_names
+    FROM
+        cards c
+        JOIN printings p ON c.id = p.card_id
+        JOIN card_sets cs ON p.card_set_id = cs.id
+        JOIN card_cycles cc ON cc.id = cs.card_cycle_id
+    GROUP BY
+        c.id
+),
+card_sets_summary AS (
+    SELECT
+        c.id,
+        ARRAY_AGG(
+            cs.id ORDER BY cs.id
+        ) as card_set_ids,
+        ARRAY_AGG(
+            LOWER(cs.name) ORDER BY LOWER(cs.name)
+        ) as card_set_names
+    FROM
+        cards c
+        JOIN printings p ON c.id = p.card_id
+        JOIN card_sets cs ON p.card_set_id = cs.id
+    GROUP BY
+        c.id
+),
+card_subtype_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            card_subtype_id
+            ORDER BY
+                1
+        ) as card_subtype_ids
+    FROM
+        cards_card_subtypes
+    GROUP BY
+        card_id
+),
+card_subtype_names AS (
+    SELECT
+        ccs.card_id,
+        -- lower used for filtering
+        ARRAY_AGG(
+            LOWER(cs.name) ORDER BY LOWER(cs.name)
+        ) as lower_card_subtype_names,
+        -- proper case used for display
+        ARRAY_AGG(
+            cs.name ORDER BY cs.name
+        ) as card_subtype_names
+    FROM
+        cards_card_subtypes ccs
+        JOIN card_subtypes cs ON ccs.card_subtype_id = cs.id
+    GROUP BY
+        ccs.card_id
+),
+card_printing_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            id ORDER BY date_release DESC
+        ) as printing_ids
+    FROM
+        printings
+    GROUP BY
+        card_id
+),
+card_release_dates AS (
+    SELECT
+        card_id,
+        MIN(date_release) as date_release
+    FROM
+        printings
+    GROUP BY
+        card_id
+),
+card_restriction_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restriction_ids
+    FROM
+        unified_restrictions
+    WHERE
+        in_restriction
+    GROUP BY
+        1
+),
+restrictions_banned_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_banned
+    FROM
+        restrictions_cards_banned
+    GROUP BY
+        card_id
+),
+restrictions_global_penalty_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_global_penalty
+    FROM
+        restrictions_cards_global_penalty
+    GROUP BY
+        card_id
+),
+restrictions_points_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            CONCAT(restriction_id, '=', CAST (value AS text))
+            ORDER BY CONCAT(restriction_id, '=', CAST (value AS text))
+        ) as restrictions_points
+    FROM
+        restrictions_cards_points
+    GROUP BY
+        card_id
+),
+restrictions_restricted_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_restricted
+    FROM
+        restrictions_cards_restricted
+    GROUP BY
+        card_id
+),
+restrictions_universal_faction_cost_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            CONCAT(restriction_id, '=', CAST (value AS text))
+            ORDER BY CONCAT(restriction_id, '=', CAST (value AS text))
+        ) as restrictions_universal_faction_cost
+    FROM
+        restrictions_cards_universal_faction_cost
+    GROUP BY
+        card_id
+),
+format_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.format_id ORDER BY s.format_id
+        ) as format_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+),
+card_pool_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.card_pool_id ORDER BY s.card_pool_id
+        ) as card_pool_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+),
+snapshot_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.id ORDER BY s.id
+        ) as snapshot_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+)
+SELECT
+    c.id as id,
+    c.title,
+    c.stripped_title,
+    c.card_type_id,
+    c.side_id,
+    c.faction_id,
+    c.advancement_requirement,
+    c.agenda_points,
+    c.base_link,
+    c.cost,
+    c.deck_limit,
+    c.influence_cost,
+    c.influence_limit,
+    c.memory_cost,
+    c.minimum_deck_size,
+    c.strength,
+    c.stripped_text,
+    c.text,
+    c.trash_cost,
+    c.is_unique,
+    c.display_subtypes,
+    c.attribution,
+    c.layout_id,
+    c.created_at,
+    c.updated_at,
+    c.additional_cost,
+    c.advanceable,
+    c.gains_subroutines,
+    c.interrupt,
+    c.link_provided,
+    c.mu_provided,
+    c.num_printed_subroutines,
+    c.on_encounter_effect,
+    c.performs_trace,
+    c.recurring_credits_provided,
+    c.rez_effect,
+    c.trash_ability,
+    COALESCE(csi.card_subtype_ids, ARRAY [] :: text []) as card_subtype_ids,
+    COALESCE(csn.lower_card_subtype_names, ARRAY [] :: text []) as lower_card_subtype_names,
+    COALESCE(csn.card_subtype_names, ARRAY [] :: text []) as card_subtype_names,
+    p.printing_ids,
+    ARRAY_LENGTH(p.printing_ids, 1) AS num_printings,
+    ccs.card_cycle_ids,
+    ccs.card_cycle_names,
+    css.card_set_ids,
+    css.card_set_names,
+    COALESCE(r.restriction_ids, ARRAY [] :: text []) as restriction_ids,
+    r.restriction_ids IS NOT NULL as in_restriction,
+    COALESCE(r_b.restrictions_banned, ARRAY [] :: text []) as restrictions_banned,
+    COALESCE(
+        r_g_p.restrictions_global_penalty,
+        ARRAY [] :: text []
+    ) as restrictions_global_penalty,
+    COALESCE(r_p.restrictions_points, ARRAY [] :: text []) as restrictions_points,
+    COALESCE(r_r.restrictions_restricted, ARRAY [] :: text []) as restrictions_restricted,
+    COALESCE(
+        r_u_f_c.restrictions_universal_faction_cost,
+        ARRAY [] :: text []
+    ) as restrictions_universal_faction_cost,
+    COALESCE(f.format_ids, ARRAY [] :: text []) as format_ids,
+    COALESCE(cpc.card_pool_ids, ARRAY [] :: text []) as card_pool_ids,
+    COALESCE(s.snapshot_ids, ARRAY [] :: text []) as snapshot_ids,
+    crd.date_release
+FROM
+    cards c
+    JOIN card_printing_ids p ON c.id = p.card_id
+    JOIN card_cycles_summary ccs ON c.id = ccs.id
+    JOIN card_sets_summary css ON c.id = css.id
+    LEFT JOIN card_subtype_ids csi ON c.id = csi.card_id
+    LEFT JOIN card_subtype_names csn ON c.id = csn.card_id
+    LEFT JOIN card_restriction_ids r ON c.id = r.card_id
+    LEFT JOIN restrictions_banned_summary r_b ON c.id = r_b.card_id
+    LEFT JOIN restrictions_global_penalty_summary r_g_p ON c.id = r_g_p.card_id
+    LEFT JOIN restrictions_points_summary r_p ON c.id = r_p.card_id
+    LEFT JOIN restrictions_restricted_summary r_r ON c.id = r_r.card_id
+    LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON c.id = r_u_f_c.card_id
+    LEFT JOIN format_ids f ON c.id = f.card_id
+    LEFT JOIN card_pool_ids cpc ON c.id = cpc.card_id
+    LEFT JOIN snapshot_ids s ON c.id = s.card_id
+    LEFT JOIN card_release_dates crd ON c.id = crd.card_id
+GROUP BY
+    c.id,
+    c.title,
+    c.stripped_title,
+    c.card_type_id,
+    c.side_id,
+    c.faction_id,
+    c.advancement_requirement,
+    c.agenda_points,
+    c.base_link,
+    c.cost,
+    c.deck_limit,
+    c.influence_cost,
+    c.influence_limit,
+    c.memory_cost,
+    c.minimum_deck_size,
+    c.strength,
+    c.stripped_text,
+    c.text,
+    c.trash_cost,
+    c.is_unique,
+    c.display_subtypes,
+    c.attribution,
+    c.created_at,
+    c.updated_at,
+    c.additional_cost,
+    c.advanceable,
+    c.gains_subroutines,
+    c.interrupt,
+    c.link_provided,
+    c.mu_provided,
+    c.num_printed_subroutines,
+    c.on_encounter_effect,
+    c.performs_trace,
+    c.recurring_credits_provided,
+    c.rez_effect,
+    c.trash_ability,
+    csi.card_subtype_ids,
+    csn.lower_card_subtype_names,
+    csn.card_subtype_names,
+    p.printing_ids,
+    ccs.card_cycle_ids,
+    ccs.card_cycle_names,
+    css.card_set_ids,
+    css.card_set_names,
+    r.restriction_ids,
+    r_b.restrictions_banned,
+    r_g_p.restrictions_global_penalty,
+    r_p.restrictions_points,
+    r_r.restrictions_restricted,
+    r_u_f_c.restrictions_universal_faction_cost,
+    f.format_ids,
+    cpc.card_pool_ids,
+    s.snapshot_ids,
+    crd.date_release;

--- a/db/views/unified_printings_v04.sql
+++ b/db/views/unified_printings_v04.sql
@@ -1,0 +1,272 @@
+WITH
+card_cycles_summary AS (
+    SELECT
+        c.id,
+        ARRAY_AGG(
+            cc.id ORDER BY cc.id
+        ) as card_cycle_ids,
+        ARRAY_AGG(
+            LOWER(cc.name) ORDER BY LOWER(cc.name)
+        ) as card_cycle_names
+    FROM
+        cards c
+        JOIN printings p ON c.id = p.card_id
+        JOIN card_sets cs ON p.card_set_id = cs.id
+        JOIN card_cycles cc ON cc.id = cs.card_cycle_id
+    GROUP BY
+        c.id
+),
+card_sets_summary AS (
+    SELECT
+        c.id,
+        ARRAY_AGG(
+            cs.id ORDER BY cs.id
+        ) as card_set_ids,
+        ARRAY_AGG(
+            LOWER(cs.name) ORDER BY LOWER(cs.name)
+        ) as card_set_names
+    FROM
+        cards c
+        JOIN printings p ON c.id = p.card_id
+        JOIN card_sets cs ON p.card_set_id = cs.id
+    GROUP BY
+        c.id
+),
+card_subtype_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(card_subtype_id ORDER BY 1) as card_subtype_ids
+    FROM
+        cards_card_subtypes
+    GROUP BY
+        card_id
+),
+card_subtype_names AS (
+    SELECT
+        ccs.card_id,
+        -- lower used for filtering
+        ARRAY_AGG(LOWER(cs.name) ORDER BY LOWER(cs.name)) as lower_card_subtype_names,
+        -- proper case used for display
+        ARRAY_AGG(
+            cs.name ORDER BY cs.name
+        ) as card_subtype_names
+    FROM
+        cards_card_subtypes ccs
+        JOIN card_subtypes cs ON ccs.card_subtype_id = cs.id
+    GROUP BY
+        ccs.card_id
+),
+card_printing_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(id ORDER BY date_release DESC) as printing_ids
+    FROM
+        printings
+    GROUP BY
+        card_id
+),
+illustrators AS (
+    SELECT
+        ip.printing_id,
+        ARRAY_AGG(ip.illustrator_id ORDER BY ip.illustrator_id) as illustrator_ids,
+        ARRAY_AGG(i.name ORDER BY i.name) as illustrator_names
+    FROM
+        illustrators_printings ip JOIN illustrators i ON ip.illustrator_id = i.id
+    GROUP BY
+        ip.printing_id
+),
+card_restriction_ids AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restriction_ids
+    FROM
+        unified_restrictions
+    WHERE
+        in_restriction
+    GROUP BY
+        1
+),
+restrictions_banned_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_banned
+    FROM
+        restrictions_cards_banned
+    GROUP BY
+        card_id
+),
+restrictions_global_penalty_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_global_penalty
+    FROM
+        restrictions_cards_global_penalty
+    GROUP BY
+        card_id
+),
+restrictions_points_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            CONCAT(restriction_id, '=', CAST (value AS text))
+            ORDER BY CONCAT(restriction_id, '=', CAST (value AS text))
+        ) as restrictions_points
+    FROM
+        restrictions_cards_points
+    GROUP BY
+        card_id
+),
+restrictions_restricted_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            restriction_id ORDER BY restriction_id
+        ) as restrictions_restricted
+    FROM
+        restrictions_cards_restricted
+    GROUP BY
+        card_id
+),
+restrictions_universal_faction_cost_summary AS (
+    SELECT
+        card_id,
+        ARRAY_AGG(
+            CONCAT(restriction_id, '=', CAST (value AS text))
+            ORDER BY CONCAT(restriction_id, '=', CAST (value AS text))
+        ) as restrictions_universal_faction_cost
+    FROM
+        restrictions_cards_universal_faction_cost
+    GROUP BY
+        card_id
+),
+format_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.format_id ORDER BY s.format_id
+        ) as format_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+),
+card_pool_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.card_pool_id ORDER BY s.card_pool_id
+        ) as card_pool_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+),
+snapshot_ids AS (
+    SELECT
+        cpc.card_id,
+        ARRAY_AGG(
+            DISTINCT s.id ORDER BY s.id
+        ) as snapshot_ids
+    FROM
+        card_pools_cards cpc
+        JOIN snapshots s ON cpc.card_pool_id = s.card_pool_id
+    GROUP BY
+        cpc.card_id
+)
+SELECT
+    p.id,
+    p.card_id,
+    cc.id as card_cycle_id,
+    cc.name as card_cycle_name,
+    p.card_set_id,
+    cs.name as card_set_name,
+    p.flavor,
+    p.display_illustrators,
+    p.position,
+    p.quantity,
+    p.date_release,
+    c.layout_id,
+    p.created_at,
+    p.updated_at,
+    c.additional_cost,
+    c.advanceable,
+    c.advancement_requirement,
+    c.agenda_points,
+    c.base_link,
+    c.card_type_id,
+    c.cost,
+    c.faction_id,
+    c.gains_subroutines,
+    c.influence_cost,
+    c.interrupt,
+    c.is_unique,
+    c.link_provided,
+    c.memory_cost,
+    c.mu_provided,
+    c.num_printed_subroutines,
+    c.on_encounter_effect,
+    c.performs_trace,
+    c.recurring_credits_provided,
+    c.side_id,
+    c.strength,
+    c.stripped_text,
+    c.stripped_title,
+    c.trash_ability,
+    c.trash_cost,
+    COALESCE(csi.card_subtype_ids, ARRAY [] :: text []) as card_subtype_ids,
+    COALESCE(csn.lower_card_subtype_names, ARRAY [] :: text []) as lower_card_subtype_names,
+    COALESCE(csn.card_subtype_names, ARRAY [] :: text []) as card_subtype_names,
+    cp.printing_ids,
+    ARRAY_LENGTH(cp.printing_ids, 1) AS num_printings,
+    COALESCE(ccs.card_cycle_ids, ARRAY [] :: text []) as card_cycle_ids,
+    COALESCE(ccs.card_cycle_names, ARRAY [] :: text []) as card_cycle_names,
+    COALESCE(css.card_set_ids, ARRAY [] :: text []) as card_set_ids,
+    COALESCE(css.card_set_names, ARRAY [] :: text []) as card_set_names,
+    COALESCE(i.illustrator_ids, ARRAY [] :: text []) as illustrator_ids,
+    COALESCE(i.illustrator_names, ARRAY [] :: text []) as illustrator_names,
+    COALESCE(r.restriction_ids, ARRAY [] :: text []) as restriction_ids,
+    r.restriction_ids IS NOT NULL as in_restriction,
+    COALESCE(r_b.restrictions_banned, ARRAY [] :: text []) as restrictions_banned,
+    COALESCE(r_g_p.restrictions_global_penalty, ARRAY [] :: text []) as restrictions_global_penalty,
+    COALESCE(r_p.restrictions_points, ARRAY [] :: text []) as restrictions_points,
+    COALESCE(r_r.restrictions_restricted, ARRAY [] :: text []) as restrictions_restricted,
+    COALESCE(r_u_f_c.restrictions_universal_faction_cost, ARRAY [] :: text []) as restrictions_universal_faction_cost,
+    COALESCE(f.format_ids, ARRAY [] :: text []) as format_ids,
+    COALESCE(cpc.card_pool_ids, ARRAY [] :: text []) as card_pool_ids,
+    COALESCE(s.snapshot_ids, ARRAY [] :: text []) as snapshot_ids,
+    c.attribution,
+    c.deck_limit,
+    c.display_subtypes,
+    c.influence_limit,
+    c.minimum_deck_size,
+    c.rez_effect,
+    c.text,
+    c.title
+FROM
+    printings p
+    INNER JOIN cards c ON p.card_id = c.id
+    JOIN card_cycles_summary ccs ON c.id = ccs.id
+    JOIN card_sets_summary css ON c.id = css.id
+    INNER JOIN card_sets cs ON p.card_set_id = cs.id
+    INNER JOIN card_cycles cc ON cs.card_cycle_id = cc.id
+    LEFT JOIN card_subtype_ids csi ON c.id = csi.card_id
+    LEFT JOIN card_subtype_names csn ON c.id = csn.card_id
+    INNER JOIN card_printing_ids cp ON p.card_id = cp.card_id
+    LEFT JOIN illustrators i ON p.id = i.printing_id
+    LEFT JOIN card_restriction_ids r ON p.card_id = r.card_id
+    LEFT JOIN restrictions_banned_summary r_b ON p.card_id = r_b.card_id
+    LEFT JOIN restrictions_global_penalty_summary r_g_p ON p.card_id = r_g_p.card_id
+    LEFT JOIN restrictions_points_summary r_p ON p.card_id = r_p.card_id
+    LEFT JOIN restrictions_restricted_summary r_r ON p.card_id = r_r.card_id
+    LEFT JOIN restrictions_universal_faction_cost_summary r_u_f_c ON p.card_id = r_u_f_c.card_id
+    LEFT JOIN format_ids f ON p.card_id = f.card_id
+    LEFT JOIN card_pool_ids cpc ON p.card_id = cpc.card_id
+    LEFT JOIN snapshot_ids s ON p.card_id = s.card_id

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -311,7 +311,14 @@ namespace :cards do
         end
       end
 
-      CardFace.import new_faces, on_duplicate_key_update: { conflict_target: [ :id ], columns: :all }
+      puts '  About to save %d card faces...' % new_faces.length
+      num_faces = 0
+      new_faces.each_slice(250) { |s|
+        num_faces += s.length
+        puts '  %d faces' % num_faces
+        CardFace.import s, on_duplicate_key_update: { conflict_target: [ :id ], columns: :all }
+      }
+
       CardCardFace.import cards_to_card_faces, on_duplicate_key_update: { conflict_target: [ :card_id, :card_face_id ], columns: :all }
       CardFaceCardSubtype.import card_faces_to_card_subtypes, on_duplicate_key_update: { conflict_target: [ :card_face_id, :card_subtype_id ], columns: :all }
     end

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -237,6 +237,9 @@ namespace :cards do
       cards_to_card_faces = []
       card_faces_to_card_subtypes = []
       cards.each do |card|
+        # Only generate faces for cards with multiple faces
+        next if !card.key?('layout_id') || card['layout_id'].nil? || card['layout_id'] == 'normal'
+
         # The first face of each card is generated from its base stats
         new_face = CardFace.new(
           id: card["id"] + '_0',
@@ -269,10 +272,7 @@ namespace :cards do
           end
         end
 
-        # Generate no additional faces for normal cards
-        next if !card.key?('layout_id') || card['layout_id'].nil? || card['layout_id'] == 'normal'
-
-        # The rest of the faces (if any) are generated from the explicitly-defined faces of the card
+        # The rest of the faces are generated from the explicitly-defined faces of the card
         # Missing attributes are assumed to be unchanged and are copied from the base stats
         i = 0
         card['faces'].each do |face|
@@ -514,6 +514,9 @@ namespace :cards do
       printings_to_printing_faces = []
       printing_faces_to_illustrators = []
       printings.each do |printing|
+        # Only generate faces for printings with multiple faces
+        next if !printing.key?('layout_id') || printing['layout_id'].nil? || printing['layout_id'] == 'normal'
+
         # The first face of each printing is generated from its base stats
         new_face = PrintingFace.new(
           id: printing["id"] + '_0',
@@ -536,10 +539,7 @@ namespace :cards do
           }
         end
 
-        # Generate no additional faces for normal printings
-        next if !printing.key?('layout_id') || printing['layout_id'].nil? || printing['layout_id'] == 'normal'
-
-        # The rest of the faces (if any) are generated from the explicitly-defined faces of the card
+        # The rest of the faces are generated from the explicitly-defined faces of the card
         # Missing attributes are assumed to be unchanged and are copied from the base stats
         i = 0
         printing['faces'].each do |face|

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -548,9 +548,6 @@ namespace :cards do
             id: printing["id"] + '_' + i.to_s,
             printing_id: printing["id"],
           )
-          new_face.printed_text = face.key?("printed_text") ? face["printed_text"] : printing["printed_text"]
-          new_face.stripped_printed_text = face.key?("stripped_printed_text") ? face["stripped_printed_text"] : printing["stripped_printed_text"]
-          new_face.printed_is_unique = face.key?("printed_is_unique") ? face["printed_is_unique"] : printing["printed_is_unique"]
           new_face.flavor = face.key?("flavor") ? face["flavor"] : printing["flavor"]
           new_face.display_illustrators = face.key?("illustrator") ? face["illustrator"] : printing["illustrator"]
           new_face.copy_quantity = face.key?("copy_quantity") ? face["copy_quantity"] : printing["copy_quantity"]

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -107,7 +107,7 @@ namespace :cards do
         is_unique: card["is_unique"],
         display_subtypes: flatten_subtypes(subtypes, card["subtypes"]),
         attribution: card["attribution"],
-        layout_id: card.key?("layout_id") ? card["layout_id"] : 'single-sided',
+        layout_id: card.key?("layout_id") ? card["layout_id"] : 'normal',
       )
       if card.key?("cost")
         new_card.cost = (card["cost"].nil? ? -1 : card["cost"])
@@ -270,12 +270,12 @@ namespace :cards do
         end
 
         # Generate no additional faces for normal cards
-        next if !card.key?('layout_id') || card['layout_id'].nil? || card['layout_id'] == 'single-sided'
+        next if !card.key?('layout_id') || card['layout_id'].nil? || card['layout_id'] == 'normal'
 
         # The rest of the faces (if any) are generated from the explicitly-defined faces of the card
         # Missing attributes are assumed to be unchanged and are copied from the base stats
         i = 0
-        card['sides'].each do |face|
+        card['faces'].each do |face|
           i += 1
           face_subtypes = face.key?("subtypes") ? face["subtypes"] : card["subtypes"]
           new_face = CardFace.new(
@@ -537,12 +537,12 @@ namespace :cards do
         end
 
         # Generate no additional faces for normal printings
-        next if !printing.key?('layout_id') || printing['layout_id'].nil? || printing['layout_id'] == 'single-sided'
+        next if !printing.key?('layout_id') || printing['layout_id'].nil? || printing['layout_id'] == 'normal'
 
         # The rest of the faces (if any) are generated from the explicitly-defined faces of the card
         # Missing attributes are assumed to be unchanged and are copied from the base stats
         i = 0
-        printing['sides'].each do |face|
+        printing['faces'].each do |face|
           i += 1
           new_face = PrintingFace.new(
             id: printing["id"] + '_' + i.to_s,

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -214,19 +214,19 @@ namespace :cards do
   def import_card_faces(cards)
     # Use a transaction since we are deleting the card face and mapping tables.
     ActiveRecord::Base.transaction do
-      puts 'Clear out existing card -> card face mappings'
+      puts '  Clear out existing card -> card face mappings'
       unless ActiveRecord::Base.connection.delete("DELETE FROM cards_card_faces")
         puts 'Hit an error while deleting card -> card face mappings. rolling back.'
         raise ActiveRecord::Rollback
       end
 
-      puts 'Clear out existing card face -> card subtype mappings'
+      puts '  Clear out existing card face -> card subtype mappings'
       unless ActiveRecord::Base.connection.delete("DELETE FROM card_faces_card_subtypes")
         puts 'Hit an error while deleting card face -> card subtype mappings. rolling back.'
         raise ActiveRecord::Rollback
       end
 
-      puts 'Clear out existing card faces'
+      puts '  Clear out existing card faces'
       unless ActiveRecord::Base.connection.delete("DELETE FROM card_faces")
         puts 'Hit an error while deleting card faces. rolling back.'
         raise ActiveRecord::Rollback
@@ -438,13 +438,13 @@ namespace :cards do
   def import_illustrators()
     # Use a transaction since we are deleting the illustrator and mapping tables.
     ActiveRecord::Base.transaction do
-      puts 'Clear out existing illustrator -> printing mappings'
+      puts '  Clear out existing illustrator -> printing mappings'
       unless ActiveRecord::Base.connection.delete("DELETE FROM illustrators_printings")
         puts 'Hit an error while deleting illustrator -> printing mappings. rolling back.'
         raise ActiveRecord::Rollback
       end
 
-      puts 'Clear out existing illustrators'
+      puts '  Clear out existing illustrators'
       unless ActiveRecord::Base.connection.delete("DELETE FROM illustrators")
         puts 'Hit an error while deleting illustrators. rolling back.'
         raise ActiveRecord::Rollback


### PR DESCRIPTION
This PR will implement [the multi-sided card data](https://github.com/NetrunnerDB/netrunner-cards-json/pull/746) in the API.

In it's current form, cards and printings have card/printing faces associated with them respectively that can be accessed through a relationship. All cards/printings have at least one face, where multi-sided cards have multiple. Any data omitted in the source JSON faces will be copied from the base card/printing.

Some issues:
- Does not unify card faces with printing faces as the existing API does for cards and printings
- Cards/printings are inconsistent
  - some multi-sided cards have only one printing face (SYNC: Everything, Everywhere ~~all at once~~)
  - some multi-sided printings only have one card face (Matryoshka)
- Card images are not yet supported across faces
  - the flip sides of cards aren't yet available on nrdb so would need uploading

I also want to change the terminology in the source json to match this better:
- `sides` -> `faces`
- the layout ID `single-sided` -> `normal`
`single-sided` was originally `normal` but I changed it. I'm not sure that change was good though since, if Netrunner ever starts printing cards like MtG, then it becomes inaccurate.

## Example of card faces:
![Evidence Collection](https://github.com/NetrunnerDB/netrunnerdb-api-server/assets/26557961/3334cc9b-6175-4132-bb9d-b09494eb5863)

## Example of printing faces:
![Matryoshka](https://github.com/NetrunnerDB/netrunnerdb-api-server/assets/26557961/e2d0972d-3380-4450-938a-28abb4666a3c)
