### PR TITLE
Added some missing relationships

### DIFF
--- a/app/models/printing.rb
+++ b/app/models/printing.rb
@@ -6,6 +6,7 @@ class Printing < ApplicationRecord
   belongs_to :unified_card, primary_key: :id, foreign_key: :card_id
   has_one :faction, :through => :card
   has_one :card_cycle, :through => :card_set
+  has_one :card_type, :through => :card
   has_one :side, :through => :card
   has_many :illustrator_printings
   has_many :illustrators, :through => :illustrator_printings

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -4,6 +4,8 @@ class Snapshot < ApplicationRecord
   belongs_to :format
   belongs_to :card_pool
   belongs_to :restriction, optional: :true
+  has_many :card_cycles, through: :card_pool
+  has_many :card_sets, through: :card_pool
   has_many :cards, through: :card_pool
   has_many :unified_cards, through: :card_pool, primary_key: :card_id, foreign_key: :id
 end

--- a/app/models/unified_printing.rb
+++ b/app/models/unified_printing.rb
@@ -11,6 +11,7 @@ class UnifiedPrinting < ApplicationRecord
   belongs_to :card_set
   has_one :faction, :through => :card
   has_one :card_cycle, :through => :card_set
+  has_one :card_type, :through => :card
   has_one :side, :through => :card
   has_many :illustrator_printings, primary_key: :id, foreign_key: :printing_id
   has_many :illustrators, :through => :illustrator_printings

--- a/app/resources/api/v3/public/printing_resource.rb
+++ b/app/resources/api/v3/public/printing_resource.rb
@@ -28,6 +28,7 @@ module API
         has_one :card, relation_name: :unified_card
         has_one :card_cycle
         has_one :card_set
+        has_one :card_type
         has_one :faction
         has_many :illustrators
         has_one :side

--- a/app/resources/api/v3/public/snapshot_resource.rb
+++ b/app/resources/api/v3/public/snapshot_resource.rb
@@ -15,6 +15,8 @@ module API
         has_one :card_pool
         has_one :restriction
 
+        has_many :card_cycles
+        has_many :card_sets
         has_many :cards, relation_name: :unified_cards
 
         filters :active, :format_id


### PR DESCRIPTION
- Printings/unified printings can see their type (through their card)
- Snapshots can see their cycles and sets (through their card pools)