### PR TITLE
Add an API endpoint for deck validation.

### DIFF
--- a/app/controllers/api/v3/public/validate_deck_controller.rb
+++ b/app/controllers/api/v3/public/validate_deck_controller.rb
@@ -1,0 +1,35 @@
+module API
+    module V3
+      module Public
+        class Api::V3::Public::ValidateDeckController < ::ApplicationController
+          def index
+            out = params[:data]
+
+            if out.nil? or not (out.has_key?(:attributes) and out[:attributes].has_key?(:identity_card_id) and out[:attributes].has_key?(:side_id) and out[:attributes].has_key?(:cards))
+              return render json: {
+                :errors => [{
+                  :title => "Invalid request",
+                  :detail => "Valid requests must be of the form `{'data': { 'attributes': { 'identity_card_id': 'foo', 'side_id': 'bar', 'cards': { } } }
+}`. Extra fields are allowed.",
+                  :code => "400",
+                  :status => "400"
+                }]}, :status => :bad_request
+            end
+
+            deck = {
+              'identity_card_id' => params[:data][:attributes][:identity_card_id],
+              'side_id' => params[:data][:attributes][:side_id],
+              'cards' => {}
+            }
+            params[:data][:attributes][:cards].each {|c,q| deck['cards'][c] = q}
+
+            v = DeckValidator.new(deck)
+
+            out[:attributes][:is_valid] = v.is_valid?
+            out[:attributes][:errors] = v.errors
+            render json: { data: out }
+          end
+        end
+      end
+    end
+  end

--- a/app/controllers/api/v3/public/validate_deck_controller.rb
+++ b/app/controllers/api/v3/public/validate_deck_controller.rb
@@ -5,6 +5,7 @@ module API
           def index
             out = params[:data]
 
+            # Check for presence of everything needed to perform deck validation and error if not present.
             if out.nil? or not (out.has_key?(:attributes) and out[:attributes].has_key?(:identity_card_id) and out[:attributes].has_key?(:side_id) and out[:attributes].has_key?(:cards))
               return render json: {
                 :errors => [{
@@ -16,6 +17,7 @@ module API
                 }]}, :status => :bad_request
             end
 
+            # Deck validation works off of a simple datastructure, so construct it instead of passing around ActionController::Parameters
             deck = {
               'identity_card_id' => params[:data][:attributes][:identity_card_id],
               'side_id' => params[:data][:attributes][:side_id],
@@ -26,8 +28,8 @@ module API
             v = DeckValidator.new(deck)
 
             out[:attributes][:is_valid] = v.is_valid?
-            out[:attributes][:errors] = v.errors
-            render json: { data: out }
+            out[:attributes][:validation_errors] = v.errors
+            render json: { data: out }, :status => :ok
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
         jsonapi_resources :rulings, only: [:index]
         jsonapi_resources :sides, only: [:index, :show]
         jsonapi_resources :snapshots, only: [:index, :show]
+        post :validate_deck, to: 'validate_deck#index'
       end
     end
   end


### PR DESCRIPTION
Expose an API endpoint for deck validation using the new deck validation library.

This echoes the input format of the deck controller, but is a bit weird because this isn't a normal JSONAPI operation.

If the request is valid, the response will return the original request with 2 extra attributes added: `is_valid` and `validation_errors`, like this:

```
{
  "data": {
    "attributes": {
      "is_valid": false,
      "validation_errors": [
        "Card `hostile_architecture` has a deck limit of 3, but 4 copies are included.",
        "Deck with size 50 requires [22,23] agenda points, but deck only has 20"
      ]
  }
}
```

A valid deck will look like this:
```
{
  "data": {
    "attributes": {
      "is_valid": true,
      "validation_errors": []
  }
}
```