### PR TITLE
Make restiction points and universal_faction_cost a hash of card_id and value

### DIFF
--- a/app/resources/api/v3/public/restriction_resource.rb
+++ b/app/resources/api/v3/public/restriction_resource.rb
@@ -16,9 +16,9 @@ module API
         def verdicts
           { 'banned': @model.banned_cards.pluck(:card_id),
             'restricted': @model.restricted_cards.pluck(:card_id),
-            'universal_faction_cost': Hash[@model.universal_faction_cost_cards.pluck(:value, :card_id).group_by(&:first).map{ |k,a| [k,a.map(&:last)] }],
+            'universal_faction_cost': @model.universal_faction_cost_cards.pluck(:card_id, :value).to_h,
             'global_penalty': @model.global_penalty_cards.pluck(:card_id),
-            'points': Hash[@model.points_cards.pluck(:value, :card_id).group_by(&:first).map{ |k,a| [k,a.map(&:last)] }]
+            'points': @model.points_cards.pluck(:card_id, :value).to_h,
           }
         end
 
@@ -27,13 +27,7 @@ module API
         end
 
         def size
-          verdicts.reduce(0) do |n, (_,v)|
-            if v.kind_of?(Array) then
-              n + v.length()
-            else
-              n + v.reduce(0) { |m, (_,a)| m + a.length() }
-            end
-          end
+          verdicts.map { |(_,v)| v.length() }.sum
         end
       end
     end


### PR DESCRIPTION
PR for my suggestion here: #199 

Changes restriction `points` and `universal_faction_cost` from:
```json
{
  "universal_faction_cost": {
    "1": [
      "architect",
      ...
    ],
    "3": [
      "blackmail",
      ...
    ]
  },
  "points": {
    "1": [
      "24_7_news_cycle",
      ...
    ],
    "2": [
      "accelerated_diagnostics",
      ...
    ],
    "3": [
      "account_siphon",
      ...
    ]
  }
}
```

to:
```json
{
  "universal_faction_cost": {
    "architect": 1,
    "blackmail": 3,
    ...
  },
  "points": {
    "24_7_news_cycle": 1,
    "accelerated_diagnostics": 2,
    "account_siphon": 3,
    ...
  }
}
```

This has a few benefits:
* The value is now returned as a number instead of a string which the client would need to parse.
* It's easier for the client to lookup the value for a card
  `const points = restriction.verdicts.points[card_id]`.