### PR TITLE
Fix `Content-Type`

### DIFF
--- a/lib/tasks/krakend.rake
+++ b/lib/tasks/krakend.rake
@@ -8,6 +8,7 @@ namespace :krakend do
     # Base config, including API documentation endpoints.
     return {
       'version' => 3,
+      'content_type' => 'application/vnd.api+json',
       'name' => 'NRDB v3 API',
       'timeout' => '5s',
       'output_encoding' => 'json',


### PR DESCRIPTION
JSONAPI expects `Content-Type` to be `application/vnd.api+json`. After #203 was merged, the return type changed to `application/json`.

This PR fixes that.