### PR TITLE
Combine coverage reports from unit and rspec tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
+        with:
+            files: ./coverage/spec/coverage.xml,./coverage/unit/coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,7 +98,7 @@ require 'rspec_api_documentation/dsl'
 RspecApiDocumentation.configure do |config|
   config.format = :json
 
-  config.request_headers_to_include = ['Host', 'Content-Type'] 
+  config.request_headers_to_include = ['Host', 'Content-Type']
   config.response_headers_to_include = ['Content-Type']
 
   config.curl_host = 'https://api-preview.netrunnerdb.com'


### PR DESCRIPTION
`rails t` and `rspec` are generating independent coverage reports.  Combine them to improve coverage accuracy.