### PR TITLE
Use DB attributes to avoid unneccessary queries from relations.

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -11,7 +11,7 @@ class Card < ApplicationRecord
   self.primary_key = :id
 
   def latest_printing_id
-    printing_ids[0]
+    printing_ids_in_database[0]
   rescue StandardError
     nil
   end

--- a/app/resources/card_resource.rb
+++ b/app/resources/card_resource.rb
@@ -38,12 +38,16 @@ class CardResource < ApplicationResource # rubocop:disable Metrics/ClassLength
   attribute :text, :string
   attribute :trash_cost, :integer
   attribute :is_unique, :boolean
-  attribute :card_subtype_ids, :array_of_strings
+  attribute :card_subtype_ids, :array_of_strings do
+    @object.card_subtype_ids_in_database
+  end
   attribute :display_subtypes, :string
   attribute :attribution, :string
   attribute :updated_at, :datetime
   attribute :format_ids, :array_of_strings
-  attribute :card_pool_ids, :array_of_strings
+  attribute :card_pool_ids, :array_of_strings do
+    @object.card_pool_ids_in_database
+  end
   attribute :snapshot_ids, :array_of_strings
   attribute :card_cycle_ids, :array_of_strings do
     @object.card_cycle_ids_in_database
@@ -94,18 +98,18 @@ class CardResource < ApplicationResource # rubocop:disable Metrics/ClassLength
   many_to_many :card_cycles do
     link do |c|
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.card_cycles_url,
-                                           ids: c.card_cycle_ids.join(','))
+                                           ids: c.card_cycle_ids_in_database.join(','))
     end
   end
   many_to_many :card_sets do
     link do |c|
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.card_sets_url,
-                                           ids: c.card_set_ids.join(','))
+                                           ids: c.card_set_ids_in_database.join(','))
     end
   end
   many_to_many :card_subtypes do
     link do |c|
-      card_subtype_ids = c.card_subtype_ids.empty? ? 'none' : c.card_subtype_ids.join(',')
+      card_subtype_ids = c.card_subtype_ids_in_database.empty? ? 'none' : c.card_subtype_ids_in_database.join(',')
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.card_subtypes_url,
                                            ids: card_subtype_ids)
     end

--- a/app/resources/printing_resource.rb
+++ b/app/resources/printing_resource.rb
@@ -14,7 +14,9 @@ class PrintingResource < ApplicationResource # rubocop:disable Metrics/ClassLeng
 
   attribute :flavor, :string
   attribute :display_illustrators, :string
-  attribute :illustrator_ids, :array_of_strings
+  attribute :illustrator_ids, :array_of_strings do
+    @object.illustrator_ids_in_database
+  end
   attribute :illustrator_names, :array_of_strings
 
   attribute :position, :integer
@@ -53,12 +55,16 @@ class PrintingResource < ApplicationResource # rubocop:disable Metrics/ClassLeng
   attribute :text, :string
   attribute :trash_cost, :integer
   attribute :is_unique, :boolean
-  attribute :card_subtype_ids, :array_of_strings
+  attribute :card_subtype_ids, :array_of_strings do
+    @object.card_subtype_ids_in_database
+  end
   attribute :card_subtype_names, :array_of_strings
   attribute :display_subtypes, :string
   attribute :attribution, :string
   attribute :format_ids, :array_of_strings
-  attribute :card_pool_ids, :array_of_strings
+  attribute :card_pool_ids, :array_of_strings do
+    @object.card_pool_ids_in_database
+  end
   attribute :snapshot_ids, :array_of_strings
   attribute :card_cycle_ids, :array_of_strings do
     @object.card_cycle_ids_in_database
@@ -118,14 +124,14 @@ class PrintingResource < ApplicationResource # rubocop:disable Metrics/ClassLeng
   many_to_many :card_subtypes do
     link do |p|
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.card_subtypes_url,
-                                           ids: p.card_subtype_ids.join(','))
+                                           ids: p.card_subtype_ids_in_database.join(','))
     end
   end
 
   many_to_many :illustrators do
     link do |p|
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.illustrators_url,
-                                           ids: p.illustrator_ids.join(','))
+                                           ids: p.illustrator_ids_in_database.join(','))
     end
   end
 


### PR DESCRIPTION
This reduces /cards and /printings default load times by ~80+% by not falling back to relations for fields that already exist in the unified_{cards,printings} tables. 