### PR TITLE
Fix relationship problem for illustrators <-> printings.

### DIFF
--- a/app/controllers/illustrators_controller.rb
+++ b/app/controllers/illustrators_controller.rb
@@ -4,7 +4,11 @@
 class IllustratorsController < ApplicationController
   def index
     add_total_stat(params)
-    illustrators = IllustratorResource.all(params)
+    base_scope = Illustrator
+    if params.include?('include') && params[:include].include?('printings')
+      base_scope = Illustrator.includes(%i[printings])
+    end
+    illustrators = IllustratorResource.all(params, base_scope)
     respond_with(illustrators)
   end
 

--- a/app/resources/illustrator_resource.rb
+++ b/app/resources/illustrator_resource.rb
@@ -4,10 +4,16 @@
 class IllustratorResource < ApplicationResource
   primary_endpoint '/illustrators', %i[index show]
 
+  self.attributes_writable_by_default = false
+
   attribute :id, :string
   attribute :name, :string
   attribute :num_printings, :integer
   attribute :updated_at, :datetime
 
-  many_to_many :printings, relation_name: :printings
+  many_to_many :printings do
+    assign_each do |illustrator, printings|
+      printings.select { |p| p.illustrator_ids_in_database.include?(illustrator.id) }
+    end
+  end
 end

--- a/app/resources/printing_resource.rb
+++ b/app/resources/printing_resource.rb
@@ -3,6 +3,7 @@
 # Public resource for Printing objects.
 class PrintingResource < ApplicationResource # rubocop:disable Metrics/ClassLength
   primary_endpoint '/printings', %i[index show]
+  self.attributes_writable_by_default = false
   self.default_page_size = 1000
   self.max_page_size = 10_000
 
@@ -130,6 +131,10 @@ class PrintingResource < ApplicationResource # rubocop:disable Metrics/ClassLeng
   end
 
   many_to_many :illustrators do
+    assign_each do |printing, illustrators|
+      illustrators.select { |i| printing.illustrator_ids_in_database.include?(i.id) }
+    end
+
     link do |p|
       format('%<url>s?filter[id]=%<ids>s', url: Rails.application.routes.url_helpers.illustrators_url,
                                            ids: p.illustrator_ids_in_database.join(','))


### PR DESCRIPTION
Because printings may have multiple illustrators and an array field AND there is a join table, the default many_to_many implementation can't join these tables properly.

All of the loaded printings were attached to the first record before this fix and the query took 10x longer.