### PR TITLE
Cache public resource rendering for a week.

### DIFF
--- a/app/resources/application_resource.rb
+++ b/app/resources/application_resource.rb
@@ -13,4 +13,6 @@ class ApplicationResource < Graphiti::Resource
   self.endpoint_namespace = '/api/v3/public'
   self.autolink = true
   link(:self) { |resource| "#{endpoint[:url]}/#{resource.id}" } if endpoint[:actions].include?(:show)
+  # Cache things for a week. Cache keys will update when entities are updated.
+  self.cache_resource expires_in: 1.week # rubocop:disable Style/RedundantSelf
 end

--- a/config/initializers/graphiti.rb
+++ b/config/initializers/graphiti.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+Graphiti.cache = ::Rails.cache
+
 Graphiti.configure do |config|
+  config.cache_rendering = true
   config.pagination_links = true
 end


### PR DESCRIPTION
This does basic response caching.

It doesn't appear to work for included resources, but will still be a bit helpful, so i'm pushing this.