### PR TITLE
Fix card cycles release date calculation

### DIFF
--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -381,7 +381,7 @@ namespace :cards do
 
   def update_date_release_for_cycles
     CardCycle.all.find_each do |c|
-      c.date_release = (c.card_sets.min_by { :date_release }).date_release
+      c.date_release = c.card_sets.minimum(:date_release)
       c.save
     end
   end

--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -381,7 +381,13 @@ namespace :cards do
 
   def update_date_release_for_cycles
     CardCycle.all.find_each do |c|
-      c.date_release = c.card_sets.minimum(:date_release)
+      num_non_booster_sets = c.card_sets.where.not(card_set_type_id: 'booster_pack').count
+
+      c.date_release = if num_non_booster_sets.positive?
+                         c.card_sets.where.not(card_set_type_id: 'booster_pack').minimum(:date_release)
+                       else
+                         c.card_sets.minimum(:date_release)
+                       end
       c.save
     end
   end


### PR DESCRIPTION
This now properly calculates cycle release date as the minimum date_release for the packs in the set.