### PR TITLE
Update Dockerfile to Ruby 3.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/ruby:3.1-bookworm
+FROM mcr.microsoft.com/devcontainers/ruby:3.3-bookworm
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
 # The value is a comma-separated list of allowed domains 


### PR DESCRIPTION
This tripped me up today because I get getting 3.1 in the devcontainer.