### PR TITLE
Set API doc format back to JSON.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,7 @@ end
 require 'rspec_api_documentation/dsl'
 
 RspecApiDocumentation.configure do |config|
-  config.format = :html
+  config.format = :json
 
   config.request_headers_to_include = %w[Host Content-Type]
   config.response_headers_to_include = ['Content-Type']


### PR DESCRIPTION
I accidentally changed this a couple of weeks back.  Sorry!