### PR TITLE
Fix decklist filtering error

### DIFF
--- a/app/controllers/decklists_controller.rb
+++ b/app/controllers/decklists_controller.rb
@@ -4,7 +4,7 @@
 class DecklistsController < ApplicationController
   def index
     add_total_stat(params)
-    base_scope = Decklist.includes(:identity_card, :cards)
+    base_scope = Decklist.preload(:identity_card, :cards)
     decklists = DecklistResource.all(params, base_scope)
     respond_with(decklists)
   end

--- a/spec/resources/decklist_resource_reads_spec.rb
+++ b/spec/resources/decklist_resource_reads_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe DecklistResource, type: :resource do
         expect(d.size).to eq(1)
       end
 
-      it 'returns no results when card_id does not match' do
+      it 'returns no results when faction_id does not match' do
         params[:filter] = { card_id: { eq: 'pennyshaver' }, faction_id: { eq: 'shaper' } }
         render
         expect(d.size).to eq(0)
       end
 
       it 'returns a result with matching exclude_card_id and faction_id' do
-        params[:filter] = { exclude_card_id: { eq: 'pennyshaver' }, faction_id: { eq: 'shaper' } }
+        params[:filter] = { exclude_card_id: { eq: 'hermes' }, faction_id: { eq: 'criminal' } }
         render
         expect(d.size).to eq(1)
       end

--- a/spec/resources/decklist_resource_reads_spec.rb
+++ b/spec/resources/decklist_resource_reads_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe DecklistResource, type: :resource do
       end
     end
 
+    context 'with card_id and faction_id combined' do
+      it 'returns a result with matching card_id and faction_id' do
+        params[:filter] = { card_id: { eq: 'pennyshaver' }, faction_id: { eq: 'criminal' } }
+        render
+        expect(d.size).to eq(1)
+      end
+
+      it 'returns no results when card_id does not match' do
+        params[:filter] = { card_id: { eq: 'pennyshaver' }, faction_id: { eq: 'shaper' } }
+        render
+        expect(d.size).to eq(0)
+      end
+
+      it 'returns a result with matching exclude_card_id and faction_id' do
+        params[:filter] = { exclude_card_id: { eq: 'pennyshaver' }, faction_id: { eq: 'shaper' } }
+        render
+        expect(d.size).to eq(1)
+      end
+    end
+
     context 'with exclude_card_id' do
       let!(:corp_decklist) { Decklist.find('11111111-1111-1111-1111-111111111111') }
       let!(:runner_decklist) { Decklist.find('22222222-2222-2222-2222-222222222222') }
@@ -76,7 +96,6 @@ RSpec.describe DecklistResource, type: :resource do
         expect(decklist_ids).to include(runner_decklist.id)
       end
     end
-  end
 
   describe 'sideloading' do
     def check_included_for_id(decklist_id, include_value, resource_type, id)

--- a/spec/resources/decklist_resource_reads_spec.rb
+++ b/spec/resources/decklist_resource_reads_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe DecklistResource, type: :resource do
         expect(decklist_ids).to include(runner_decklist.id)
       end
     end
+  end
 
   describe 'sideloading' do
     def check_included_for_id(decklist_id, include_value, resource_type, id)


### PR DESCRIPTION
Currently, filtering decklists by `card_id` or `exclude_card_id` causes a 500. ([example 1](https://api.netrunnerdb.com/api/v3/public/decklists?filter[faction_id]=weyland_consortium&filter[exclude_card_id]=measured_response), [example 2](https://api.netrunnerdb.com/api/v3/public/decklists?filter[faction_id]=weyland_consortium&filter[card_id]=measured_response))

After some fiddling with `decklists_controller`, looks like `.preload` instead of `.includes` does the job well enough - https://guides.rubyonrails.org/active_record_querying.html#includes 🤷 