### PR TITLE
Update advanceable filter text

### DIFF
--- a/lib/tasks/cards.rake
+++ b/lib/tasks/cards.rake
@@ -178,7 +178,7 @@ namespace :cards do
         new_card.num_printed_subroutines = num_printed_subroutines
       end
 
-      if new_card.text&.include?(' can be advanced') && new_card.text.match("#{new_card.title} can be advanced")
+      if new_card.text&.match?("#{new_card.title} can be advanced") || new_card.text&.match?('you can advance this')
         new_card.advanceable = true
       end
 


### PR DESCRIPTION
Text filter change, should now capture modern rules text on cards like Pharos, Urtica, Vlad City Grid, etc.

https://netrunnerdb.com/find/?q=x%3A%22you+can+advance+this%22&sort=name&view=images&_locale=en