### PR TITLE
Remove foreign keys we aren't ready for from old migration

### DIFF
--- a/db/migrate/20260520044700_add_missing_foreign_keys.rb
+++ b/db/migrate/20260520044700_add_missing_foreign_keys.rb
@@ -2,12 +2,6 @@
 
 class AddMissingForeignKeys < ActiveRecord::Migration[8.1]
   def change
-    # User constraints
-    add_foreign_key :decklists, :users
-    add_foreign_key :reviews, :users
-    add_foreign_key :review_comments, :users
-    add_foreign_key :review_votes, :users
-
     # card_faces constraints
     add_foreign_key :card_faces, :cards
 


### PR DESCRIPTION
i had not deployed the FK addition migration i made a while back and only saw it caused problems when trying to deploy to the api-preview server today.